### PR TITLE
Port table layout panel from visualizers package

### DIFF
--- a/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
@@ -1,0 +1,98 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using System.Xml.Serialization;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that specifies a mashup visualizer panel that can be used
+    /// to arrange other visualizers in a grid.
+    /// </summary>
+    [DefaultProperty(nameof(CellSpans))]
+    [TypeVisualizer(typeof(TableLayoutPanelVisualizer))]
+    [Description("Specifies a mashup visualizer panel that can be used to arrange other visualizers in a grid.")]
+    public class TableLayoutPanelBuilder : VariableArgumentExpressionBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableLayoutPanelBuilder"/> class.
+        /// </summary>
+        public TableLayoutPanelBuilder()
+            : base(minArguments: 0, maxArguments: 1)
+        {
+            ColumnCount = 1;
+            RowCount = 1;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the visualizer window.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The name of the visualizer window.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of columns in the visualizer grid layout.
+        /// </summary>
+        [Description("The number of columns in the visualizer grid layout.")]
+        public int ColumnCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of rows in the visualizer grid layout.
+        /// </summary>
+        [Description("The number of rows in the visualizer grid layout.")]
+        public int RowCount { get; set; }
+
+        /// <summary>
+        /// Gets a collection of <see cref="ColumnStyle"/> objects specifying the size
+        /// ratio of the columns in the visualizer grid layout.
+        /// </summary>
+        [Category("Table Style")]
+        [Description("Specifies the optional size ratio of the columns in the visualizer grid layout.")]
+        public Collection<ColumnStyle> ColumnStyles { get; } = new Collection<ColumnStyle>();
+
+        /// <summary>
+        /// Gets a collection of <see cref="RowStyle"/> objects specifying the size ratio
+        /// of the rows in the visualizer grid layout.
+        /// </summary>
+        [Category("Table Style")]
+        [Description("Specifies the optional size ratio of the rows in the visualizer grid layout.")]
+        public Collection<RowStyle> RowStyles { get; } = new Collection<RowStyle>();
+
+        /// <summary>
+        /// Gets a collection of <see cref="TableLayoutPanelCellSpan"/> objects specifying the
+        /// column and row span of each cell in the visualizer grid layout.
+        /// </summary>
+        [Category("Table Style")]
+        [XmlArrayItem("CellSpan")]
+        [Description("Specifies the optional column and row span of each cell in the visualizer grid layout.")]
+        public Collection<TableLayoutPanelCellSpan> CellSpans { get; } = new Collection<TableLayoutPanelCellSpan>();
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// table layout panel visualizer.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.SingleOrDefault();
+            if (source == null)
+            {
+                return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
+            }
+            else return Expression.Call(typeof(TableLayoutPanelBuilder), nameof(Process), source.Type.GetGenericArguments(), source);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source;
+        }
+    }
+}

--- a/src/Bonsai.Gui/TableLayoutPanelCellSpan.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelCellSpan.cs
@@ -1,0 +1,49 @@
+﻿using System.Xml.Serialization;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents the vertical and horizontal span of a table layout cell.
+    /// </summary>
+    public class TableLayoutPanelCellSpan
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableLayoutPanelCellSpan"/> class.
+        /// </summary>
+        public TableLayoutPanelCellSpan()
+        {
+            ColumnSpan = 1;
+            RowSpan = 1;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableLayoutPanelCellSpan"/> class
+        /// using the specified column and row span.
+        /// </summary>
+        /// <param name="columnSpan">The number of columns spanned by the table layout cell.</param>
+        /// <param name="rowSpan">The number of rows spanned by the table layout cell.</param>
+        public TableLayoutPanelCellSpan(int columnSpan, int rowSpan)
+        {
+            ColumnSpan = columnSpan;
+            RowSpan = rowSpan;
+        }
+
+        /// <summary>
+        /// Gets the number of columns spanned by this table layout cell.
+        /// </summary>
+        [XmlAttribute]
+        public int ColumnSpan { get; set; }
+
+        /// <summary>
+        /// Gets the number of rows spanned by this table layout cell.
+        /// </summary>
+        [XmlAttribute]
+        public int RowSpan { get; set; }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"ColumnSpan = {ColumnSpan}, RowSpan = {RowSpan}";
+        }
+    }
+}

--- a/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
@@ -1,0 +1,190 @@
+﻿using Bonsai;
+using Bonsai.Design;
+using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using Bonsai.Gui;
+
+[assembly: TypeVisualizer(typeof(DialogTypeVisualizer), Target = typeof(MashupSource<TableLayoutPanelVisualizer>))]
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer that can be used to arrange other visualizers in a grid.
+    /// </summary>
+    public class TableLayoutPanelVisualizer : MashupVisualizer
+    {
+        internal TableLayoutPanel Panel { get; private set; }
+
+        static void SetStyles(TableLayoutStyleCollection styles, IReadOnlyList<TableLayoutStyle> builderStyles, int count, Func<TableLayoutStyle> defaultStyle)
+        {
+            if (builderStyles.Count > 0)
+            {
+                foreach (var style in builderStyles)
+                {
+                    styles.Add(style);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    styles.Add(defaultStyle());
+                }
+            }
+        }
+
+        void UpdateLayoutPanel(TableLayoutPanelBuilder tableLayoutBuilder)
+        {
+            var columnCount = tableLayoutBuilder.ColumnCount;
+            var rowCount = tableLayoutBuilder.RowCount;
+            if (columnCount == 0 && rowCount == 0)
+            {
+                throw new InvalidOperationException("The table layout must have at least one non-zero dimension.");
+            }
+            if (columnCount == 0) columnCount = MashupSources.Count / rowCount;
+            if (rowCount == 0) rowCount = MashupSources.Count / columnCount;
+
+            Panel.ColumnCount = columnCount;
+            Panel.RowCount = rowCount;
+            SetStyles(Panel.ColumnStyles, tableLayoutBuilder.ColumnStyles, columnCount, () => new ColumnStyle(SizeType.Percent, 100f / columnCount));
+            SetStyles(Panel.RowStyles, tableLayoutBuilder.RowStyles, rowCount, () => new RowStyle(SizeType.Percent, 100f / rowCount));
+        }
+
+        /// <inheritdoc/>
+        public override MashupSource GetMashupSource(int x, int y)
+        {
+            if (Panel == null) return null;
+            var panelPoint = Panel.PointToClient(new Point(x, y));
+            var childControl = Panel.GetChildAtPoint(panelPoint);
+            if (childControl != null)
+            {
+                var index = Panel.Controls.GetChildIndex(childControl);
+                return MashupSources[index];
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            Panel = new TableLayoutPanel();
+            Panel.Dock = DockStyle.Fill;
+            Panel.Size = new Size(320, 240);
+            base.Load(provider);
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(Panel);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void LoadMashups(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var tableLayoutBuilder = (TableLayoutPanelBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            UpdateLayoutPanel(tableLayoutBuilder);
+            var container = new TableLayoutPanelContainer(this, tableLayoutBuilder.CellSpans, provider);
+            foreach (var source in MashupSources)
+            {
+                source.Visualizer.Load(container);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void UnloadMashups()
+        {
+            base.UnloadMashups();
+            Panel.Controls.Clear();
+            Panel.RowStyles.Clear();
+            Panel.ColumnStyles.Clear();
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
+        {
+            return MashupSources.Select(xs => xs.Visualizer.Visualize(xs.Source.Output, provider)).Merge();
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            base.Unload();
+            Panel.Dispose();
+            Panel = null;
+        }
+
+        class TableLayoutPanelContainer : IDialogTypeVisualizerService, IServiceProvider
+        {
+            public TableLayoutPanelContainer(TableLayoutPanelVisualizer visualizer, IReadOnlyList<TableLayoutPanelCellSpan> cellSpans, IServiceProvider provider)
+            {
+                Visualizer = visualizer ?? throw new ArgumentNullException(nameof(visualizer));
+                CellSpans = cellSpans ?? throw new ArgumentNullException(nameof(cellSpans));
+                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            }
+
+            private TableLayoutPanelVisualizer Visualizer { get; }
+
+            private IReadOnlyList<TableLayoutPanelCellSpan> CellSpans { get; }
+
+            private IServiceProvider Provider { get; }
+
+            public void AddControl(Control control)
+            {
+                int column, row;
+                var panel = Visualizer.Panel;
+                var index = panel.Controls.Count;
+                if (panel.ColumnCount == 0)
+                {
+                    column = index / panel.RowCount;
+                    row = index % panel.RowCount;
+                }
+                else
+                {
+                    column = index % panel.ColumnCount;
+                    row = index / panel.ColumnCount;
+                }
+                panel.Controls.Add(control, column, row);
+                if (index < CellSpans.Count)
+                {
+                    var cellSpan = CellSpans[index];
+                    panel.SetColumnSpan(control, cellSpan.ColumnSpan);
+                    panel.SetRowSpan(control, cellSpan.RowSpan);
+                }
+            }
+
+            public object GetService(Type serviceType)
+            {
+                if (serviceType == typeof(IDialogTypeVisualizerService))
+                {
+                    return this;
+                }
+
+                if (serviceType == typeof(MashupVisualizer))
+                {
+                    return Visualizer;
+                }
+
+                if (serviceType == typeof(ITypeVisualizerContext))
+                {
+                    var index = Visualizer.Panel.Controls.Count;
+                    return Visualizer.MashupSources[index];
+                }
+
+                return Provider.GetService(serviceType);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR ports the `TableLayoutPanel` control from the visualizers package. The goal is to start from a self-contained clean slate with no dependencies to allow faster iteration on the UI composition API.