### PR TITLE
Add core infrastructure for control visualizers

### DIFF
--- a/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
@@ -59,6 +59,7 @@ namespace Bonsai.Gui
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
             Control = CreateControl(provider, controlBuilder);
+            Control.SubscribeTo(controlBuilder);
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(Control);

--- a/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.Linq;
-using System.Reactive.Linq;
 using System.Windows.Forms;
 using Bonsai.Design;
 using Bonsai.Expressions;
@@ -19,52 +17,16 @@ namespace Bonsai.Gui
     /// The type of the workflow element used to create the container control.
     /// </typeparam>
     public abstract class ContainerControlVisualizerBase<TControl, TControlBuilder>
-        : MashupVisualizer
+        : MashupControlVisualizerBase<TControl, TControlBuilder>
         where TControl : Control
         where TControlBuilder : ExpressionBuilder
     {
-        /// <summary>
-        /// Gets the active container control exposed by this type visualizer.
-        /// </summary>
-        protected TControl Control { get; private set; }
-
-        /// <summary>
-        /// Creates and configures the container control associated with
-        /// the specified workflow operator.
-        /// </summary>
-        /// <param name="provider">
-        /// A service provider object which can be used to obtain visualization,
-        /// runtime inspection, or other editing services.
-        /// </param>
-        /// <param name="builder">
-        /// The <see cref="ExpressionBuilder"/> object used to provide configuration
-        /// properties to the container control.
-        /// </param>
-        /// <returns>
-        /// A new instance of the container control class associated with the specified
-        /// workflow operator.
-        /// </returns>
-        protected abstract TControl CreateControl(IServiceProvider provider, TControlBuilder builder);
-
         /// <summary>
         /// Adds a control to the container at the specified index.
         /// </summary>
         /// <param name="index">The index of the control, following the order of visualizer sources.</param>
         /// <param name="control">The control to add to the container.</param>
         protected abstract void AddControl(int index, Control control);
-
-        /// <inheritdoc/>
-        public override void Load(IServiceProvider provider)
-        {
-            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
-            Control = CreateControl(provider, controlBuilder);
-            Control.SubscribeTo(controlBuilder);
-
-            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
-            visualizerService?.AddControl(Control);
-            base.Load(provider);
-        }
 
         /// <inheritdoc/>
         public override void LoadMashups(IServiceProvider provider)
@@ -75,6 +37,13 @@ namespace Bonsai.Gui
                 var containerProvider = new ContainerControlServiceProvider(i, this, mashupSource.Source, provider);
                 mashupSource.Visualizer.Load(containerProvider);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void UnloadMashups()
+        {
+            base.UnloadMashups();
+            Control.Controls.Clear();
         }
 
         /// <inheritdoc/>
@@ -92,66 +61,31 @@ namespace Bonsai.Gui
             return null;
         }
 
-        /// <inheritdoc/>
-        public override void Show(object value)
-        {
-        }
-
-        /// <inheritdoc/>
-        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
-        {
-            return MashupSources.Select(xs => xs.Visualizer.Visualize(xs.Source.Output, provider)).Merge();
-        }
-
-        /// <inheritdoc/>
-        public override void Unload()
-        {
-            base.Unload();
-            Control.Dispose();
-            Control = null;
-        }
-
-        class ContainerControlServiceProvider : IDialogTypeVisualizerService, ITypeVisualizerContext, IServiceProvider
+        class ContainerControlServiceProvider : MashupControlServiceProvider, IDialogTypeVisualizerService
         {
             public ContainerControlServiceProvider(
                 int index,
                 ContainerControlVisualizerBase<TControl, TControlBuilder> visualizer,
                 InspectBuilder source,
                 IServiceProvider provider)
+                : base(index, visualizer, source, provider)
             {
-                Index = index;
-                Visualizer = visualizer ?? throw new ArgumentNullException(nameof(visualizer));
-                Source = source ?? throw new ArgumentNullException(nameof(source));
-                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
             }
-
-            public int Index { get; }
-
-            public ContainerControlVisualizerBase<TControl, TControlBuilder> Visualizer { get; }
-
-            public InspectBuilder Source { get; }
-
-            public IServiceProvider Provider { get; }
 
             public void AddControl(Control control)
             {
-                Visualizer.AddControl(Index, control);
+                var container = (ContainerControlVisualizerBase<TControl, TControlBuilder>)Visualizer;
+                container.AddControl(Index, control);
             }
 
-            public object GetService(Type serviceType)
+            public override object GetService(Type serviceType)
             {
-                if (serviceType == typeof(IDialogTypeVisualizerService) ||
-                    serviceType == typeof(ITypeVisualizerContext))
+                if (serviceType == typeof(IDialogTypeVisualizerService))
                 {
                     return this;
                 }
 
-                if (serviceType == typeof(MashupVisualizer))
-                {
-                    return Visualizer;
-                }
-
-                return Provider.GetService(serviceType);
+                return base.GetService(serviceType);
             }
         }
     }

--- a/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using Bonsai.Design;
+using Bonsai.Expressions;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class for visualizers representing UI elements which can
+    /// contain other nested UI elements.
+    /// </summary>
+    /// <typeparam name="TControl">
+    /// The type of the container control exposed by this type visualizer.
+    /// </typeparam>
+    /// <typeparam name="TControlBuilder">
+    /// The type of the workflow element used to create the container control.
+    /// </typeparam>
+    public abstract class ContainerControlVisualizerBase<TControl, TControlBuilder>
+        : MashupVisualizer
+        where TControl : Control
+        where TControlBuilder : ExpressionBuilder
+    {
+        /// <summary>
+        /// Gets the active container control exposed by this type visualizer.
+        /// </summary>
+        protected TControl Control { get; private set; }
+
+        /// <summary>
+        /// Creates and configures the container control associated with
+        /// the specified workflow operator.
+        /// </summary>
+        /// <param name="provider">
+        /// A service provider object which can be used to obtain visualization,
+        /// runtime inspection, or other editing services.
+        /// </param>
+        /// <param name="builder">
+        /// The <see cref="ExpressionBuilder"/> object used to provide configuration
+        /// properties to the container control.
+        /// </param>
+        /// <returns>
+        /// A new instance of the container control class associated with the specified
+        /// workflow operator.
+        /// </returns>
+        protected abstract TControl CreateControl(IServiceProvider provider, TControlBuilder builder);
+
+        /// <summary>
+        /// Adds a control to the container at the specified index.
+        /// </summary>
+        /// <param name="index">The index of the control, following the order of visualizer sources.</param>
+        /// <param name="control">The control to add to the container.</param>
+        protected abstract void AddControl(int index, Control control);
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            Control = CreateControl(provider, controlBuilder);
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            visualizerService?.AddControl(Control);
+            base.Load(provider);
+        }
+
+        /// <inheritdoc/>
+        public override void LoadMashups(IServiceProvider provider)
+        {
+            for (int i = 0; i < MashupSources.Count; i++)
+            {
+                var mashupSource = MashupSources[i];
+                var containerProvider = new ContainerControlServiceProvider(i, this, mashupSource.Source, provider);
+                mashupSource.Visualizer.Load(containerProvider);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override MashupSource GetMashupSource(int x, int y)
+        {
+            if (Control == null) return null;
+            var panelPoint = Control.PointToClient(new Point(x, y));
+            var childControl = Control.GetChildAtPoint(panelPoint);
+            if (childControl != null)
+            {
+                var index = Control.Controls.GetChildIndex(childControl);
+                return MashupSources[index];
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
+        {
+            return MashupSources.Select(xs => xs.Visualizer.Visualize(xs.Source.Output, provider)).Merge();
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            base.Unload();
+            Control.Dispose();
+            Control = null;
+        }
+
+        class ContainerControlServiceProvider : IDialogTypeVisualizerService, ITypeVisualizerContext, IServiceProvider
+        {
+            public ContainerControlServiceProvider(
+                int index,
+                ContainerControlVisualizerBase<TControl, TControlBuilder> visualizer,
+                InspectBuilder source,
+                IServiceProvider provider)
+            {
+                Index = index;
+                Visualizer = visualizer ?? throw new ArgumentNullException(nameof(visualizer));
+                Source = source ?? throw new ArgumentNullException(nameof(source));
+                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            }
+
+            public int Index { get; }
+
+            public ContainerControlVisualizerBase<TControl, TControlBuilder> Visualizer { get; }
+
+            public InspectBuilder Source { get; }
+
+            public IServiceProvider Provider { get; }
+
+            public void AddControl(Control control)
+            {
+                Visualizer.AddControl(Index, control);
+            }
+
+            public object GetService(Type serviceType)
+            {
+                if (serviceType == typeof(IDialogTypeVisualizerService) ||
+                    serviceType == typeof(ITypeVisualizerContext))
+                {
+                    return this;
+                }
+
+                if (serviceType == typeof(MashupVisualizer))
+                {
+                    return Visualizer;
+                }
+
+                return Provider.GetService(serviceType);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -88,7 +88,7 @@ namespace Bonsai.Gui
     /// </summary>
     /// <typeparam name="TCommand">The type of command notifications accepted by the UI control.</typeparam>
     /// <typeparam name="TEvent">The type of event notifications emitted by the UI control.</typeparam>
-    public abstract class ControlBuilderBase<TCommand, TEvent> : ControlBuilderBase, INamedElement
+    public abstract class ControlBuilderBase<TCommand, TEvent> : ControlBuilderBase<TEvent>, INamedElement
     {
         static readonly Range<int> argumentRange = Range.Create(lowerBound: 0, upperBound: 1);
 
@@ -107,14 +107,6 @@ namespace Bonsai.Gui
             var commands = source == null ? Array.Empty<Expression>() : new[] { source };
             return Expression.Call(Expression.Constant(this), nameof(Generate), null, commands);
         }
-
-        /// <summary>
-        /// Generates an observable sequence of event notifications from the UI control.
-        /// </summary>
-        /// <returns>
-        /// An observable sequence of events of type <typeparamref name="TEvent"/>.
-        /// </returns>
-        protected abstract IObservable<TEvent> Generate();
 
         /// <summary>
         /// Generates an observable sequence of event notifications from the UI control.

--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -15,12 +15,38 @@ namespace Bonsai.Gui
     /// </summary>
     public abstract class ControlBuilderBase : ZeroArgumentExpressionBuilder, INamedElement
     {
+        internal readonly BehaviorSubject<bool> _Enabled = new(true);
+        internal readonly BehaviorSubject<bool> _Visible = new(true);
+
         /// <summary>
         /// Gets or sets the name of the control.
         /// </summary>
         [Category(nameof(CategoryAttribute.Design))]
         [Description("The name of the control.")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the control can respond to user interaction.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Behavior))]
+        [Description("Specifies whether the control can respond to user interaction.")]
+        public bool Enabled
+        {
+            get => _Enabled.Value;
+            set => _Enabled.OnNext(value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the control and all its child controls
+        /// are displayed.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Behavior))]
+        [Description("Specifies whether the control and all its child controls are displayed.")]
+        public bool Visible
+        {
+            get => _Visible.Value;
+            set => _Visible.OnNext(value);
+        }
 
         /// <summary>
         /// Builds the expression tree for configuring and calling the UI control.

--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -15,18 +15,12 @@ namespace Bonsai.Gui
     /// </summary>
     public abstract class ControlBuilderBase : ZeroArgumentExpressionBuilder, INamedElement
     {
-        internal readonly BehaviorSubject<string> _Name = new(string.Empty);
-
         /// <summary>
         /// Gets or sets the name of the control.
         /// </summary>
         [Category(nameof(CategoryAttribute.Design))]
         [Description("The name of the control.")]
-        public string Name
-        {
-            get => _Name.Value;
-            set => _Name.OnNext(value);
-        }
+        public string Name { get; set; }
 
         /// <summary>
         /// Builds the expression tree for configuring and calling the UI control.

--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using Bonsai.Expressions;
+using System.Reactive.Subjects;
+using System.Reactive.Linq;
+using System.Reactive;
+using System.Linq;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class with common UI control functionality.
+    /// </summary>
+    public abstract class ControlBuilderBase : ZeroArgumentExpressionBuilder, INamedElement
+    {
+        internal readonly BehaviorSubject<string> _Name = new(string.Empty);
+
+        /// <summary>
+        /// Gets or sets the name of the control.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The name of the control.")]
+        public string Name
+        {
+            get => _Name.Value;
+            set => _Name.OnNext(value);
+        }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the UI control.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
+        }
+    }
+
+    /// <summary>
+    /// Provides an abstract base class with common UI event source control functionality.
+    /// </summary>
+    /// <typeparam name="TEvent">The type of event notifications emitted by the UI control.</typeparam>
+    public abstract class ControlBuilderBase<TEvent> : ControlBuilderBase, INamedElement
+    {
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the UI control.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return Expression.Call(Expression.Constant(this), nameof(Generate), null);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of event notifications from the UI control.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence of events of type <typeparamref name="TEvent"/>.
+        /// </returns>
+        protected abstract IObservable<TEvent> Generate();
+    }
+
+    /// <summary>
+    /// Provides an abstract base class with common functionality for UI controls that
+    /// accept an optional sequence of command notifications.
+    /// </summary>
+    /// <typeparam name="TCommand">The type of command notifications accepted by the UI control.</typeparam>
+    /// <typeparam name="TEvent">The type of event notifications emitted by the UI control.</typeparam>
+    public abstract class ControlBuilderBase<TCommand, TEvent> : ControlBuilderBase, INamedElement
+    {
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 0, upperBound: 1);
+
+        /// <summary>
+        /// Gets the range of input arguments that this expression builder accepts.
+        /// </summary>
+        public override Range<int> ArgumentRange => argumentRange;
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the UI control.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.SingleOrDefault();
+            var commands = source == null ? Array.Empty<Expression>() : new[] { source };
+            return Expression.Call(Expression.Constant(this), nameof(Generate), null, commands);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of event notifications from the UI control.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence of events of type <typeparamref name="TEvent"/>.
+        /// </returns>
+        protected abstract IObservable<TEvent> Generate();
+
+        /// <summary>
+        /// Generates an observable sequence of event notifications from the UI control.
+        /// </summary>
+        /// <param name="source">
+        /// An observable sequence of commands of type <typeparamref name="TCommand"/>.
+        /// </param>
+        /// <returns>
+        /// An observable sequence of events of type <typeparamref name="TEvent"/>.
+        /// </returns>
+        protected abstract IObservable<TEvent> Generate(IObservable<TCommand> source);
+    }
+}

--- a/src/Bonsai.Gui/ControlExtensions.cs
+++ b/src/Bonsai.Gui/ControlExtensions.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using Bonsai.Design;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a set of static methods for subscribing delegates to
+    /// observable sequences of event notifications.
+    /// </summary>
+    public static class ControlExtensions
+    {
+        /// <summary>
+        /// Subscribes the control to change notifications in the specified
+        /// observable collection.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> collection.
+        /// </typeparam>
+        /// <param name="control">The control on which to observe notifications.</param>
+        /// <param name="source">
+        /// A data collection that provides notifications when items are added,
+        /// removed, or when the whole list is refreshed.
+        /// </param>
+        /// <param name="action">
+        /// The action to invoke on each new version of the observable collection.
+        /// </param>
+        /// <returns>
+        /// A disposable object used to unsubscribe from the observable sequence.
+        /// </returns>
+        public static IDisposable SubscribeTo<TSource>(
+            this Control control,
+            ObservableCollection<TSource> source,
+            Action<TSource[]> action)
+        {
+            var collectionChanged = Observable.FromEventPattern<NotifyCollectionChangedEventHandler, NotifyCollectionChangedEventArgs>(
+                handler => source.CollectionChanged += handler,
+                handler => source.CollectionChanged -= handler)
+                .Select(evt => source.ToArray());
+            return SubscribeTo(control, collectionChanged, action);
+        }
+
+        /// <summary>
+        /// Subscribes the control to event notifications from the specified
+        /// observable sequence.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="control">The control on which to observe notifications.</param>
+        /// <param name="source">The observable sequence of event notifications.</param>
+        /// <param name="action">The action to invoke on each event notification.</param>
+        /// <returns>
+        /// A disposable object used to unsubscribe from the observable sequence.
+        /// </returns>
+        public static IDisposable SubscribeTo<TSource>(this Control control, IObservable<TSource> source, Action<TSource> action)
+        {
+            var handleCreated = Observable.FromEventPattern<EventHandler, EventArgs>(
+                handler => control.HandleCreated += handler,
+                handler => control.HandleCreated -= handler);
+            var handleDestroyed = Observable.FromEventPattern<EventHandler, EventArgs>(
+                handler => control.HandleDestroyed += handler,
+                handler => control.HandleDestroyed -= handler);
+            var notifications = handleCreated
+                .SelectMany(_ => source.ObserveOn(control))
+                .TakeUntil(handleDestroyed);
+            return notifications.Subscribe(action);
+        }
+    }
+}

--- a/src/Bonsai.Gui/ControlExtensions.cs
+++ b/src/Bonsai.Gui/ControlExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Windows.Forms;
 using Bonsai.Design;
+using Bonsai.Expressions;
 
 namespace Bonsai.Gui
 {
@@ -69,6 +70,20 @@ namespace Bonsai.Gui
                 .SelectMany(_ => source.ObserveOn(control))
                 .TakeUntil(handleDestroyed);
             return notifications.Subscribe(action);
+        }
+
+        internal static void SubscribeTo(this Control control, ExpressionBuilder builder)
+        {
+            if (string.IsNullOrEmpty(control.Name))
+            {
+                control.Name = ExpressionBuilder.GetElementDisplayName(builder);
+            }
+
+            if (builder is ControlBuilderBase controlBuilder)
+            {
+                control.SubscribeTo(controlBuilder._Enabled, value => control.Enabled = value);
+                control.SubscribeTo(controlBuilder._Visible, value => control.Visible = value);
+            }
         }
     }
 }

--- a/src/Bonsai.Gui/ControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ControlVisualizerBase.cs
@@ -44,6 +44,10 @@ namespace Bonsai.Gui
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
             Control = CreateControl(provider, controlBuilder);
+            if (string.IsNullOrEmpty(Control.Name))
+            {
+                Control.Name = ExpressionBuilder.GetElementDisplayName(controlBuilder);
+            }
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(Control);

--- a/src/Bonsai.Gui/ControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ControlVisualizerBase.cs
@@ -44,10 +44,7 @@ namespace Bonsai.Gui
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
             Control = CreateControl(provider, controlBuilder);
-            if (string.IsNullOrEmpty(Control.Name))
-            {
-                Control.Name = ExpressionBuilder.GetElementDisplayName(controlBuilder);
-            }
+            Control.SubscribeTo(controlBuilder);
 
             var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
             visualizerService?.AddControl(Control);

--- a/src/Bonsai.Gui/ControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ControlVisualizerBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using System.Xml.Serialization;
 using Bonsai.Design;
 using Bonsai.Expressions;
 
@@ -18,7 +19,8 @@ namespace Bonsai.Gui
         /// <summary>
         /// Gets the active control exposed by this type visualizer.
         /// </summary>
-        protected TControl Control { get; private set; }
+        [XmlIgnore]
+        public TControl Control { get; private set; }
 
         /// <summary>
         /// Creates and configures the visual control associated with

--- a/src/Bonsai.Gui/ControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ControlVisualizerBase.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Windows.Forms;
+using Bonsai.Design;
+using Bonsai.Expressions;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class for visualizers representing individual UI elements.
+    /// </summary>
+    /// <typeparam name="TControl">The type of the control exposed by this type visualizer.</typeparam>
+    /// <typeparam name="TControlBuilder">The type of the workflow element used to create the control.</typeparam>
+    public abstract class ControlVisualizerBase<TControl, TControlBuilder>
+        : DialogTypeVisualizer
+        where TControl : Control
+        where TControlBuilder : ExpressionBuilder
+    {
+        /// <summary>
+        /// Gets the active control exposed by this type visualizer.
+        /// </summary>
+        protected TControl Control { get; private set; }
+
+        /// <summary>
+        /// Creates and configures the visual control associated with
+        /// the specified workflow operator.
+        /// </summary>
+        /// <param name="provider">
+        /// A service provider object which can be used to obtain visualization,
+        /// runtime inspection, or other editing services.
+        /// </param>
+        /// <param name="builder">
+        /// The <see cref="ExpressionBuilder"/> object used to provide configuration
+        /// properties to the control.
+        /// </param>
+        /// <returns>
+        /// A new instance of the control class associated with the specified
+        /// workflow operator.
+        /// </returns>
+        protected abstract TControl CreateControl(IServiceProvider provider, TControlBuilder builder);
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            Control = CreateControl(provider, controlBuilder);
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            visualizerService?.AddControl(Control);
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            Control.Dispose();
+            Control = null;
+        }
+    }
+}

--- a/src/Bonsai.Gui/MashupControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/MashupControlVisualizerBase.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Windows.Forms;
+using System.Xml.Serialization;
+using Bonsai.Design;
+using Bonsai.Expressions;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class for visualizers representing UI elements which can
+    /// be combined with other visualizers.
+    /// </summary>
+    /// <typeparam name="TControl">
+    /// The type of the control exposed by this mashup visualizer.
+    /// </typeparam>
+    /// <typeparam name="TControlBuilder">
+    /// The type of the workflow element used to create the mashup control.
+    /// </typeparam>
+    public abstract class MashupControlVisualizerBase<TControl, TControlBuilder>
+        : MashupVisualizer
+        where TControl : Control
+        where TControlBuilder : ExpressionBuilder
+    {
+        /// <summary>
+        /// Gets the active mashup control exposed by this type visualizer.
+        /// </summary>
+        [XmlIgnore]
+        public TControl Control { get; private set; }
+
+        /// <summary>
+        /// Creates and configures the mashup control associated with
+        /// the specified workflow operator.
+        /// </summary>
+        /// <param name="provider">
+        /// A service provider object which can be used to obtain visualization,
+        /// runtime inspection, or other editing services.
+        /// </param>
+        /// <param name="builder">
+        /// The <see cref="ExpressionBuilder"/> object used to provide configuration
+        /// properties to the mashup control.
+        /// </param>
+        /// <returns>
+        /// A new instance of the mashup control class associated with the specified
+        /// workflow operator.
+        /// </returns>
+        protected abstract TControl CreateControl(IServiceProvider provider, TControlBuilder builder);
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var controlBuilder = (TControlBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            Control = CreateControl(provider, controlBuilder);
+            Control.SubscribeTo(controlBuilder);
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            visualizerService?.AddControl(Control);
+            base.Load(provider);
+        }
+
+        /// <inheritdoc/>
+        public override void LoadMashups(IServiceProvider provider)
+        {
+            for (int i = 0; i < MashupSources.Count; i++)
+            {
+                var mashupSource = MashupSources[i];
+                var mashupServiceProvider = new MashupControlServiceProvider(i, this, mashupSource.Source, provider);
+                mashupSource.Visualizer.Load(mashupServiceProvider);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
+        {
+            return MashupSources.Select(xs => xs.Visualizer.Visualize(xs.Source.Output, provider)).Merge();
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            base.Unload();
+            Control.Dispose();
+            Control = null;
+        }
+
+        internal class MashupControlServiceProvider : ITypeVisualizerContext, IServiceProvider
+        {
+            public MashupControlServiceProvider(
+                int index,
+                MashupVisualizer visualizer,
+                InspectBuilder source,
+                IServiceProvider provider)
+            {
+                Index = index;
+                Visualizer = visualizer ?? throw new ArgumentNullException(nameof(visualizer));
+                Source = source ?? throw new ArgumentNullException(nameof(source));
+                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            }
+
+            public int Index { get; }
+
+            public MashupVisualizer Visualizer { get; }
+
+            public InspectBuilder Source { get; }
+
+            public IServiceProvider Provider { get; }
+
+            public virtual object GetService(Type serviceType)
+            {
+                if (serviceType == typeof(ITypeVisualizerContext))
+                {
+                    return this;
+                }
+
+                if (serviceType == typeof(MashupVisualizer))
+                {
+                    return Visualizer;
+                }
+
+                return Provider.GetService(serviceType);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
@@ -1,12 +1,5 @@
-﻿using Bonsai.Expressions;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reactive;
-using System.Reactive.Linq;
 using System.Windows.Forms;
 using System.Xml.Serialization;
 
@@ -19,36 +12,19 @@ namespace Bonsai.Gui
     [DefaultProperty(nameof(CellSpans))]
     [TypeVisualizer(typeof(TableLayoutPanelVisualizer))]
     [Description("Specifies a mashup visualizer panel that can be used to arrange other visualizers in a grid.")]
-    public class TableLayoutPanelBuilder : VariableArgumentExpressionBuilder, INamedElement
+    public class TableLayoutPanelBuilder : ControlBuilderBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TableLayoutPanelBuilder"/> class.
-        /// </summary>
-        public TableLayoutPanelBuilder()
-            : base(minArguments: 0, maxArguments: 1)
-        {
-            ColumnCount = 1;
-            RowCount = 1;
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the visualizer window.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("The name of the visualizer window.")]
-        public string Name { get; set; }
-
         /// <summary>
         /// Gets or sets the number of columns in the visualizer grid layout.
         /// </summary>
         [Description("The number of columns in the visualizer grid layout.")]
-        public int ColumnCount { get; set; }
+        public int ColumnCount { get; set; } = 1;
 
         /// <summary>
         /// Gets or sets the number of rows in the visualizer grid layout.
         /// </summary>
         [Description("The number of rows in the visualizer grid layout.")]
-        public int RowCount { get; set; }
+        public int RowCount { get; set; } = 1;
 
         /// <summary>
         /// Gets a collection of <see cref="ColumnStyle"/> objects specifying the size
@@ -56,7 +32,7 @@ namespace Bonsai.Gui
         /// </summary>
         [Category("Table Style")]
         [Description("Specifies the optional size ratio of the columns in the visualizer grid layout.")]
-        public Collection<ColumnStyle> ColumnStyles { get; } = new Collection<ColumnStyle>();
+        public Collection<ColumnStyle> ColumnStyles { get; } = new();
 
         /// <summary>
         /// Gets a collection of <see cref="RowStyle"/> objects specifying the size ratio
@@ -64,7 +40,7 @@ namespace Bonsai.Gui
         /// </summary>
         [Category("Table Style")]
         [Description("Specifies the optional size ratio of the rows in the visualizer grid layout.")]
-        public Collection<RowStyle> RowStyles { get; } = new Collection<RowStyle>();
+        public Collection<RowStyle> RowStyles { get; } = new();
 
         /// <summary>
         /// Gets a collection of <see cref="TableLayoutPanelCellSpan"/> objects specifying the
@@ -73,26 +49,6 @@ namespace Bonsai.Gui
         [Category("Table Style")]
         [XmlArrayItem("CellSpan")]
         [Description("Specifies the optional column and row span of each cell in the visualizer grid layout.")]
-        public Collection<TableLayoutPanelCellSpan> CellSpans { get; } = new Collection<TableLayoutPanelCellSpan>();
-
-        /// <summary>
-        /// Builds the expression tree for configuring and calling the
-        /// table layout panel visualizer.
-        /// </summary>
-        /// <inheritdoc/>
-        public override Expression Build(IEnumerable<Expression> arguments)
-        {
-            var source = arguments.SingleOrDefault();
-            if (source == null)
-            {
-                return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
-            }
-            else return Expression.Call(typeof(TableLayoutPanelBuilder), nameof(Process), source.Type.GetGenericArguments(), source);
-        }
-
-        static IObservable<TSource> Process<TSource>(IObservable<TSource> source)
-        {
-            return source;
-        }
+        public Collection<TableLayoutPanelCellSpan> CellSpans { get; } = new();
     }
 }

--- a/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelBuilder.cs
@@ -30,7 +30,7 @@ namespace Bonsai.Gui
         /// Gets a collection of <see cref="ColumnStyle"/> objects specifying the size
         /// ratio of the columns in the visualizer grid layout.
         /// </summary>
-        [Category("Table Style")]
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies the optional size ratio of the columns in the visualizer grid layout.")]
         public Collection<ColumnStyle> ColumnStyles { get; } = new();
 
@@ -38,7 +38,7 @@ namespace Bonsai.Gui
         /// Gets a collection of <see cref="RowStyle"/> objects specifying the size ratio
         /// of the rows in the visualizer grid layout.
         /// </summary>
-        [Category("Table Style")]
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies the optional size ratio of the rows in the visualizer grid layout.")]
         public Collection<RowStyle> RowStyles { get; } = new();
 
@@ -46,8 +46,8 @@ namespace Bonsai.Gui
         /// Gets a collection of <see cref="TableLayoutPanelCellSpan"/> objects specifying the
         /// column and row span of each cell in the visualizer grid layout.
         /// </summary>
-        [Category("Table Style")]
         [XmlArrayItem("CellSpan")]
+        [Category(nameof(CategoryAttribute.Layout))]
         [Description("Specifies the optional column and row span of each cell in the visualizer grid layout.")]
         public Collection<TableLayoutPanelCellSpan> CellSpans { get; } = new();
     }

--- a/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
@@ -59,7 +59,6 @@ namespace Bonsai.Gui
             var panel = new TableLayoutPanel();
             panel.Dock = DockStyle.Fill;
             panel.Size = new Size(320, 240);
-            panel.Name = builder.Name;
             panelBuilder = builder;
             return panel;
         }

--- a/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
@@ -98,7 +98,6 @@ namespace Bonsai.Gui
         public override void UnloadMashups()
         {
             base.UnloadMashups();
-            Control.Controls.Clear();
             Control.RowStyles.Clear();
             Control.ColumnStyles.Clear();
         }

--- a/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
+++ b/src/Bonsai.Gui/TableLayoutPanelVisualizer.cs
@@ -1,11 +1,8 @@
 ﻿using Bonsai;
 using Bonsai.Design;
-using Bonsai.Expressions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Reactive.Linq;
 using System.Windows.Forms;
 using Bonsai.Gui;
 
@@ -16,9 +13,9 @@ namespace Bonsai.Gui
     /// <summary>
     /// Provides a type visualizer that can be used to arrange other visualizers in a grid.
     /// </summary>
-    public class TableLayoutPanelVisualizer : MashupVisualizer
+    public class TableLayoutPanelVisualizer : ContainerControlVisualizerBase<TableLayoutPanel, TableLayoutPanelBuilder>
     {
-        internal TableLayoutPanel Panel { get; private set; }
+        TableLayoutPanelBuilder panelBuilder;
 
         static void SetStyles(TableLayoutStyleCollection styles, IReadOnlyList<TableLayoutStyle> builderStyles, int count, Func<TableLayoutStyle> defaultStyle)
         {
@@ -38,10 +35,11 @@ namespace Bonsai.Gui
             }
         }
 
-        void UpdateLayoutPanel(TableLayoutPanelBuilder tableLayoutBuilder)
+        void UpdateLayoutPanel()
         {
-            var columnCount = tableLayoutBuilder.ColumnCount;
-            var rowCount = tableLayoutBuilder.RowCount;
+            var panel = Control;
+            var columnCount = panelBuilder.ColumnCount;
+            var rowCount = panelBuilder.RowCount;
             if (columnCount == 0 && rowCount == 0)
             {
                 throw new InvalidOperationException("The table layout must have at least one non-zero dimension.");
@@ -49,142 +47,68 @@ namespace Bonsai.Gui
             if (columnCount == 0) columnCount = MashupSources.Count / rowCount;
             if (rowCount == 0) rowCount = MashupSources.Count / columnCount;
 
-            Panel.ColumnCount = columnCount;
-            Panel.RowCount = rowCount;
-            SetStyles(Panel.ColumnStyles, tableLayoutBuilder.ColumnStyles, columnCount, () => new ColumnStyle(SizeType.Percent, 100f / columnCount));
-            SetStyles(Panel.RowStyles, tableLayoutBuilder.RowStyles, rowCount, () => new RowStyle(SizeType.Percent, 100f / rowCount));
+            panel.ColumnCount = columnCount;
+            panel.RowCount = rowCount;
+            SetStyles(panel.ColumnStyles, panelBuilder.ColumnStyles, columnCount, () => new ColumnStyle(SizeType.Percent, 100f / columnCount));
+            SetStyles(panel.RowStyles, panelBuilder.RowStyles, rowCount, () => new RowStyle(SizeType.Percent, 100f / rowCount));
         }
 
         /// <inheritdoc/>
-        public override MashupSource GetMashupSource(int x, int y)
+        protected override TableLayoutPanel CreateControl(IServiceProvider provider, TableLayoutPanelBuilder builder)
         {
-            if (Panel == null) return null;
-            var panelPoint = Panel.PointToClient(new Point(x, y));
-            var childControl = Panel.GetChildAtPoint(panelPoint);
-            if (childControl != null)
+            var panel = new TableLayoutPanel();
+            panel.Dock = DockStyle.Fill;
+            panel.Size = new Size(320, 240);
+            panel.Name = builder.Name;
+            panelBuilder = builder;
+            return panel;
+        }
+
+        /// <inheritdoc/>
+        protected override void AddControl(int index, Control control)
+        {
+            int column, row;
+            var panel = Control;
+            if (panel.ColumnCount == 0)
             {
-                var index = Panel.Controls.GetChildIndex(childControl);
-                return MashupSources[index];
+                column = index / panel.RowCount;
+                row = index % panel.RowCount;
             }
-
-            return null;
-        }
-
-        /// <inheritdoc/>
-        public override void Load(IServiceProvider provider)
-        {
-            Panel = new TableLayoutPanel();
-            Panel.Dock = DockStyle.Fill;
-            Panel.Size = new Size(320, 240);
-            base.Load(provider);
-
-            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
-            if (visualizerService != null)
+            else
             {
-                visualizerService.AddControl(Panel);
+                column = index % panel.ColumnCount;
+                row = index / panel.ColumnCount;
+            }
+            panel.Controls.Add(control, column, row);
+            if (index < panelBuilder.CellSpans.Count)
+            {
+                var cellSpan = panelBuilder.CellSpans[index];
+                panel.SetColumnSpan(control, cellSpan.ColumnSpan);
+                panel.SetRowSpan(control, cellSpan.RowSpan);
             }
         }
 
         /// <inheritdoc/>
         public override void LoadMashups(IServiceProvider provider)
         {
-            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            var tableLayoutBuilder = (TableLayoutPanelBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
-            UpdateLayoutPanel(tableLayoutBuilder);
-            var container = new TableLayoutPanelContainer(this, tableLayoutBuilder.CellSpans, provider);
-            foreach (var source in MashupSources)
-            {
-                source.Visualizer.Load(container);
-            }
+            UpdateLayoutPanel();
+            base.LoadMashups(provider);
         }
 
         /// <inheritdoc/>
         public override void UnloadMashups()
         {
             base.UnloadMashups();
-            Panel.Controls.Clear();
-            Panel.RowStyles.Clear();
-            Panel.ColumnStyles.Clear();
-        }
-
-        /// <inheritdoc/>
-        public override void Show(object value)
-        {
-        }
-
-        /// <inheritdoc/>
-        public override IObservable<object> Visualize(IObservable<IObservable<object>> source, IServiceProvider provider)
-        {
-            return MashupSources.Select(xs => xs.Visualizer.Visualize(xs.Source.Output, provider)).Merge();
+            Control.Controls.Clear();
+            Control.RowStyles.Clear();
+            Control.ColumnStyles.Clear();
         }
 
         /// <inheritdoc/>
         public override void Unload()
         {
             base.Unload();
-            Panel.Dispose();
-            Panel = null;
-        }
-
-        class TableLayoutPanelContainer : IDialogTypeVisualizerService, IServiceProvider
-        {
-            public TableLayoutPanelContainer(TableLayoutPanelVisualizer visualizer, IReadOnlyList<TableLayoutPanelCellSpan> cellSpans, IServiceProvider provider)
-            {
-                Visualizer = visualizer ?? throw new ArgumentNullException(nameof(visualizer));
-                CellSpans = cellSpans ?? throw new ArgumentNullException(nameof(cellSpans));
-                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
-            }
-
-            private TableLayoutPanelVisualizer Visualizer { get; }
-
-            private IReadOnlyList<TableLayoutPanelCellSpan> CellSpans { get; }
-
-            private IServiceProvider Provider { get; }
-
-            public void AddControl(Control control)
-            {
-                int column, row;
-                var panel = Visualizer.Panel;
-                var index = panel.Controls.Count;
-                if (panel.ColumnCount == 0)
-                {
-                    column = index / panel.RowCount;
-                    row = index % panel.RowCount;
-                }
-                else
-                {
-                    column = index % panel.ColumnCount;
-                    row = index / panel.ColumnCount;
-                }
-                panel.Controls.Add(control, column, row);
-                if (index < CellSpans.Count)
-                {
-                    var cellSpan = CellSpans[index];
-                    panel.SetColumnSpan(control, cellSpan.ColumnSpan);
-                    panel.SetRowSpan(control, cellSpan.RowSpan);
-                }
-            }
-
-            public object GetService(Type serviceType)
-            {
-                if (serviceType == typeof(IDialogTypeVisualizerService))
-                {
-                    return this;
-                }
-
-                if (serviceType == typeof(MashupVisualizer))
-                {
-                    return Visualizer;
-                }
-
-                if (serviceType == typeof(ITypeVisualizerContext))
-                {
-                    var index = Visualizer.Panel.Controls.Count;
-                    return Visualizer.MashupSources[index];
-                }
-
-                return Provider.GetService(serviceType);
-            }
+            panelBuilder = null;
         }
     }
 }


### PR DESCRIPTION
The package aims to provide a bridge between UI components with a visual representation (controls) and operators in a workflow. This PR aims to create a common infrastructure and provide reusable design patterns for building different control types. Specifically we are providing the following functionality:

- Infrastructure for event source controls, i.e. controls that emit notifications to the workflow
- Infrastructure for container controls, i.e. controls that can contain and be combined with other controls
- Infrastructure for controls accepting notifications from the workflow
- Data binding between operator and control properties

Existing controls have been refactored to take advantage of the shared functionality.