### PR TITLE
Add support for overriding default font

### DIFF
--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -7,6 +7,8 @@ using System.Reactive.Subjects;
 using System.Reactive.Linq;
 using System.Reactive;
 using System.Linq;
+using System.Drawing;
+using System.Xml.Serialization;
 
 namespace Bonsai.Gui
 {
@@ -17,6 +19,7 @@ namespace Bonsai.Gui
     {
         internal readonly BehaviorSubject<bool> _Enabled = new(true);
         internal readonly BehaviorSubject<bool> _Visible = new(true);
+        internal readonly BehaviorSubject<Font> _Font = new(null);
 
         /// <summary>
         /// Gets or sets the name of the control.
@@ -46,6 +49,44 @@ namespace Bonsai.Gui
         {
             get => _Visible.Value;
             set => _Visible.OnNext(value);
+        }
+
+        /// <summary>
+        /// Gets or sets the font of the text displayed by the control.
+        /// </summary>
+        [XmlIgnore]
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The font of the text displayed by the control.")]
+        public Font Font
+        {
+            get => _Font.Value;
+            set => _Font.OnNext(value);
+        }
+
+        /// <summary>
+        /// Gets or sets an XML representation of the font for serialization.
+        /// </summary>
+        [Browsable(false)]
+        [XmlElement(nameof(Font))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string FontXml
+        {
+            get
+            {
+                var font = Font;
+                if (font == null || font == SystemFonts.DefaultFont) return null;
+                var converter = new FontConverter();
+                return converter.ConvertToString(Font);
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    var converter = new FontConverter();
+                    Font = (Font)converter.ConvertFromString(value);
+                }
+                else Font = SystemFonts.DefaultFont;
+            }
         }
 
         /// <summary>

--- a/src/Bonsai.Gui/ControlExtensions.cs
+++ b/src/Bonsai.Gui/ControlExtensions.cs
@@ -83,6 +83,7 @@ namespace Bonsai.Gui
             {
                 control.SubscribeTo(controlBuilder._Enabled, value => control.Enabled = value);
                 control.SubscribeTo(controlBuilder._Visible, value => control.Visible = value);
+                control.SubscribeTo(controlBuilder._Font, value => control.Font = value);
             }
         }
     }


### PR DESCRIPTION
Customizing and overriding specific control fonts is a powerful way to customize the styling and sizing of UI elements. This PR adds a new optional `Font` property and data binding to the base control builder class.

Note that by leveraging the ambient characteristic of nested control fonts, it is possible to override the fonts of entire UIs by setting just the font of the top-level panel.