### PR TITLE
Add common button controls

### DIFF
--- a/src/Bonsai.Gui/ButtonBuilder.cs
+++ b/src/Bonsai.Gui/ButtonBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a button control and generates
+    /// a sequence of notifications whenever the button is clicked.
+    /// </summary>
+    [TypeVisualizer(typeof(ButtonVisualizer))]
+    [Description("Interfaces with a button control and generates a sequence of notifications whenever the button is clicked.")]
+    public class ButtonBuilder : ButtonBuilderBase<string>
+    {
+        internal readonly Subject<string> _Click = new();
+
+        /// <inheritdoc/>
+        protected override IObservable<string> Generate()
+        {
+            return _Click;
+        }
+    }
+}

--- a/src/Bonsai.Gui/ButtonBuilderBase.cs
+++ b/src/Bonsai.Gui/ButtonBuilderBase.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class with common button control functionality.
+    /// </summary>
+    /// <inheritdoc/>
+    [DefaultProperty(nameof(Text))]
+    public abstract class ButtonBuilderBase<TEvent> : ControlBuilderBase<TEvent>
+    {
+        internal readonly BehaviorSubject<string> _Text = new(string.Empty);
+
+        /// <summary>
+        /// Gets or sets the text associated with this control.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The text associated with this control.")]
+        public string Text
+        {
+            get => _Text.Value;
+            set => _Text.OnNext(value);
+        }
+    }
+}

--- a/src/Bonsai.Gui/ButtonVisualizer.cs
+++ b/src/Bonsai.Gui/ButtonVisualizer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a button control.
+    /// </summary>
+    public class ButtonVisualizer : ControlVisualizerBase<Button, ButtonBuilder>
+    {
+        /// <inheritdoc/>
+        protected override Button CreateControl(IServiceProvider provider, ButtonBuilder builder)
+        {
+            var button = new Button();
+            button.Dock = DockStyle.Fill;
+            button.Size = new Size(300, 150);
+            button.SubscribeTo(builder._Text, value => button.Text = value);
+            button.Click += (sender, e) =>
+            {
+                builder._Click.OnNext(button.Name);
+            };
+            return button;
+        }
+    }
+}

--- a/src/Bonsai.Gui/CheckBoxBuilder.cs
+++ b/src/Bonsai.Gui/CheckBoxBuilder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a check box control and generates
+    /// a sequence of notifications whenever the checked status changes.
+    /// </summary>
+    [TypeVisualizer(typeof(CheckBoxVisualizer))]
+    [Description("Interfaces with a check box control and generates a sequence of notifications whenever the checked status changes.")]
+    public class CheckBoxBuilder : ButtonBuilderBase<bool>
+    {
+        internal readonly Subject<bool> _CheckedChanged = new();
+
+        /// <summary>
+        /// Gets or sets a value specifying the initial state of the check box.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies the initial state of the check box.")]
+        public bool Checked { get; set; }
+
+        /// <inheritdoc/>
+        protected override IObservable<bool> Generate()
+        {
+            return _CheckedChanged;
+        }
+    }
+}

--- a/src/Bonsai.Gui/CheckBoxVisualizer.cs
+++ b/src/Bonsai.Gui/CheckBoxVisualizer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a check box control.
+    /// </summary>
+    public class CheckBoxVisualizer : ControlVisualizerBase<CheckBox, CheckBoxBuilder>
+    {
+        /// <inheritdoc/>
+        protected override CheckBox CreateControl(IServiceProvider provider, CheckBoxBuilder builder)
+        {
+            var checkBox = new CheckBox();
+            checkBox.Dock = DockStyle.Fill;
+            checkBox.Size = new Size(300, 75);
+            checkBox.Checked = builder.Checked;
+            checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
+            checkBox.CheckedChanged += (sender, e) =>
+            {
+                builder._CheckedChanged.OnNext(checkBox.Checked);
+            };
+            return checkBox;
+        }
+    }
+}

--- a/src/Bonsai.Gui/RadioButtonBuilder.cs
+++ b/src/Bonsai.Gui/RadioButtonBuilder.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a radio button control and generates
+    /// a sequence of notifications whenever the checked status changes.
+    /// </summary>
+    [TypeVisualizer(typeof(RadioButtonVisualizer))]
+    [Description("Interfaces with a radio button control and generates a sequence of notifications whenever the checked status changes.")]
+    public class RadioButtonBuilder : ButtonBuilderBase<bool>
+    {
+        internal readonly Subject<bool> _CheckedChanged = new();
+
+        /// <summary>
+        /// Gets or sets a value specifying the initial state of the radio button.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies the initial state of the radio button.")]
+        public bool Checked { get; set; }
+
+        /// <inheritdoc/>
+        protected override IObservable<bool> Generate()
+        {
+            return _CheckedChanged;
+        }
+    }
+}

--- a/src/Bonsai.Gui/RadioButtonVisualizer.cs
+++ b/src/Bonsai.Gui/RadioButtonVisualizer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a radio button control.
+    /// </summary>
+    public class RadioButtonVisualizer : ControlVisualizerBase<RadioButton, RadioButtonBuilder>
+    {
+        /// <inheritdoc/>
+        protected override RadioButton CreateControl(IServiceProvider provider, RadioButtonBuilder builder)
+        {
+            var radioButton = new RadioButton();
+            radioButton.Dock = DockStyle.Fill;
+            radioButton.Size = new Size(300, 75);
+            radioButton.Checked = builder.Checked;
+            radioButton.SubscribeTo(builder._Text, value => radioButton.Text = value);
+            radioButton.CheckedChanged += (sender, e) =>
+            {
+                builder._CheckedChanged.OnNext(radioButton.Checked);
+            };
+            return radioButton;
+        }
+    }
+}

--- a/src/Bonsai.Gui/ToggleButtonBuilder.cs
+++ b/src/Bonsai.Gui/ToggleButtonBuilder.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a toggle button control and generates
+    /// a sequence of notifications whenever the toggle status changes.
+    /// </summary>
+    [TypeVisualizer(typeof(ToggleButtonVisualizer))]
+    [Description("Interfaces with a toggle button control and generates a sequence of notifications whenever the toggle status changes.")]
+    public class ToggleButtonBuilder : ButtonBuilderBase<bool>
+    {
+        internal readonly Subject<bool> _CheckedChanged = new();
+
+        /// <inheritdoc/>
+        protected override IObservable<bool> Generate()
+        {
+            return _CheckedChanged;
+        }
+    }
+}

--- a/src/Bonsai.Gui/ToggleButtonVisualizer.cs
+++ b/src/Bonsai.Gui/ToggleButtonVisualizer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a toggle button control.
+    /// </summary>
+    public class ToggleButtonVisualizer : ControlVisualizerBase<CheckBox, ToggleButtonBuilder>
+    {
+        /// <inheritdoc/>
+        protected override CheckBox CreateControl(IServiceProvider provider, ToggleButtonBuilder builder)
+        {
+            var checkBox = new CheckBox();
+            checkBox.Dock = DockStyle.Fill;
+            checkBox.Size = new Size(300, 150);
+            checkBox.Appearance = Appearance.Button;
+            checkBox.TextAlign = ContentAlignment.MiddleCenter;
+            checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
+            checkBox.CheckedChanged += (sender, e) =>
+            {
+                builder._CheckedChanged.OnNext(checkBox.Checked);
+            };
+            return checkBox;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the following common button controls:

- `Button` (single click push button)
- `ToggleButton` (two-state button)
- `CheckBox` (two-state check box)
- `RadioButton` (when grouped with other radio buttons, ensures at most one is selected)

Common functionality is reused via the `ButtonBuilderBase` abstract class which allows setting the text on each of the buttons.