### PR TITLE
Add group box and tab control containers

### DIFF
--- a/src/Bonsai.Gui/ControlBuilderBase.cs
+++ b/src/Bonsai.Gui/ControlBuilderBase.cs
@@ -13,7 +13,7 @@ using System.Xml.Serialization;
 namespace Bonsai.Gui
 {
     /// <summary>
-    /// Provides an abstract base class with common UI control functionality.
+    /// Provides an abstract base class for common UI control functionality.
     /// </summary>
     public abstract class ControlBuilderBase : ZeroArgumentExpressionBuilder, INamedElement
     {

--- a/src/Bonsai.Gui/GroupBoxBuilder.cs
+++ b/src/Bonsai.Gui/GroupBoxBuilder.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that specifies a mashup visualizer that displays a frame
+    /// around a group of other visualizers with an optional caption.
+    /// </summary>
+    [TypeVisualizer(typeof(GroupBoxVisualizer))]
+    [Description("Specifies a mashup visualizer that displays a frame around a group of other visualizers with an optional caption.")]
+    public class GroupBoxBuilder : TextControlBuilderBase
+    {
+    }
+}

--- a/src/Bonsai.Gui/GroupBoxVisualizer.cs
+++ b/src/Bonsai.Gui/GroupBoxVisualizer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Bonsai.Design;
+using Bonsai.Gui;
+using Bonsai;
+
+[assembly: TypeVisualizer(typeof(DialogTypeVisualizer), Target = typeof(MashupSource<GroupBoxVisualizer>))]
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer that displays a frame around a group of other
+    /// visualizers with an optional caption.
+    /// </summary>
+    public class GroupBoxVisualizer : ContainerControlVisualizerBase<GroupBox, GroupBoxBuilder>
+    {
+        /// <inheritdoc/>
+        protected override void AddControl(int index, Control control)
+        {
+            Control.Controls.Add(control);
+        }
+
+        /// <inheritdoc/>
+        protected override GroupBox CreateControl(IServiceProvider provider, GroupBoxBuilder builder)
+        {
+            var groupBox = new GroupBox();
+            groupBox.Dock = DockStyle.Fill;
+            groupBox.Size = new Size(320, 240);
+            groupBox.SubscribeTo(builder._Text, value => groupBox.Text = value);
+            return groupBox;
+        }
+    }
+}

--- a/src/Bonsai.Gui/TabControlBuilder.cs
+++ b/src/Bonsai.Gui/TabControlBuilder.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that specifies a mashup visualizer that can be used
+    /// to arrange other visualizers using a related set of tab pages.
+    /// </summary>
+    [TypeVisualizer(typeof(TabControlVisualizer))]
+    [Description("Specifies a mashup visualizer that can be used to arrange other visualizers using a related set of tab pages.")]
+    public class TabControlBuilder : ControlBuilderBase
+    {
+    }
+}

--- a/src/Bonsai.Gui/TabControlVisualizer.cs
+++ b/src/Bonsai.Gui/TabControlVisualizer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Bonsai.Design;
+using Bonsai.Gui;
+using Bonsai;
+using System.Windows.Forms;
+using System.Drawing;
+
+[assembly: TypeVisualizer(typeof(DialogTypeVisualizer), Target = typeof(MashupSource<TabControlVisualizer>))]
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer that can be used to arrange other visualizers
+    /// using a related set of tab pages.
+    /// </summary>
+    public class TabControlVisualizer : ContainerControlVisualizerBase<TabControl, TabControlBuilder>
+    {
+        /// <inheritdoc/>
+        protected override TabControl CreateControl(IServiceProvider provider, TabControlBuilder builder)
+        {
+            var tabControl = new TabControl();
+            tabControl.Dock = DockStyle.Fill;
+            tabControl.Size = new Size(320, 240);
+            return tabControl;
+        }
+
+        /// <inheritdoc/>
+        protected override void AddControl(int index, Control control)
+        {
+            var tabPage = new TabPage(control.Name);
+            tabPage.Controls.Add(control);
+            Control.Controls.Add(tabPage);
+        }
+    }
+}

--- a/src/Bonsai.Gui/TextControlBuilderBase.cs
+++ b/src/Bonsai.Gui/TextControlBuilderBase.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class for common UI text control functionality.
+    /// </summary>
+    [DefaultProperty(nameof(Text))]
+    public abstract class TextControlBuilderBase : ControlBuilderBase
+    {
+        internal readonly BehaviorSubject<string> _Text = new(string.Empty);
+
+        /// <summary>
+        /// Gets or sets the text associated with this control.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The text associated with this control.")]
+        public string Text
+        {
+            get => _Text.Value;
+            set => _Text.OnNext(value);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the following container controls:

- `GroupBox` (labeled frame around a set of controls)
- `TabControl` (arrange other controls as a set of tab pages)

In the case of `TabControl`, the name of the nested controls can be used to set the text in each tab page.