### PR TITLE
Add two way binding for check button state

### DIFF
--- a/src/Bonsai.Gui/ButtonBuilderBase.cs
+++ b/src/Bonsai.Gui/ButtonBuilderBase.cs
@@ -1,26 +1,9 @@
-﻿using System.ComponentModel;
-using System.Reactive.Subjects;
-
-namespace Bonsai.Gui
+﻿namespace Bonsai.Gui
 {
     /// <summary>
     /// Provides an abstract base class with common button control functionality.
     /// </summary>
-    /// <inheritdoc/>
-    [DefaultProperty(nameof(Text))]
-    public abstract class ButtonBuilderBase<TEvent> : ControlBuilderBase<TEvent>
+    public abstract class ButtonBuilderBase<TEvent> : TextControlBuilderBase<TEvent>
     {
-        internal readonly BehaviorSubject<string> _Text = new(string.Empty);
-
-        /// <summary>
-        /// Gets or sets the text associated with this control.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("The text associated with this control.")]
-        public string Text
-        {
-            get => _Text.Value;
-            set => _Text.OnNext(value);
-        }
     }
 }

--- a/src/Bonsai.Gui/ButtonVisualizer.cs
+++ b/src/Bonsai.Gui/ButtonVisualizer.cs
@@ -15,7 +15,6 @@ namespace Bonsai.Gui
             var button = new Button();
             button.Dock = DockStyle.Fill;
             button.Size = new Size(300, 150);
-            button.SubscribeTo(builder._Text, value => button.Text = value);
             button.Click += (sender, e) =>
             {
                 builder._Click.OnNext(button.Name);

--- a/src/Bonsai.Gui/CheckBoxBuilder.cs
+++ b/src/Bonsai.Gui/CheckBoxBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Reactive.Subjects;
+﻿using System.ComponentModel;
 
 namespace Bonsai.Gui
 {
@@ -10,21 +8,7 @@ namespace Bonsai.Gui
     /// </summary>
     [TypeVisualizer(typeof(CheckBoxVisualizer))]
     [Description("Interfaces with a check box control and generates a sequence of notifications whenever the checked status changes.")]
-    public class CheckBoxBuilder : ButtonBuilderBase<bool>
+    public class CheckBoxBuilder : CheckButtonBuilderBase
     {
-        internal readonly Subject<bool> _CheckedChanged = new();
-
-        /// <summary>
-        /// Gets or sets a value specifying the initial state of the check box.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies the initial state of the check box.")]
-        public bool Checked { get; set; }
-
-        /// <inheritdoc/>
-        protected override IObservable<bool> Generate()
-        {
-            return _CheckedChanged;
-        }
     }
 }

--- a/src/Bonsai.Gui/CheckBoxVisualizer.cs
+++ b/src/Bonsai.Gui/CheckBoxVisualizer.cs
@@ -17,9 +17,10 @@ namespace Bonsai.Gui
             checkBox.Size = new Size(300, 75);
             checkBox.Checked = builder.Checked;
             checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
+            checkBox.SubscribeTo(builder._Checked, value => checkBox.Checked = value);
             checkBox.CheckedChanged += (sender, e) =>
             {
-                builder._CheckedChanged.OnNext(checkBox.Checked);
+                builder._Checked.OnNext(checkBox.Checked);
             };
             return checkBox;
         }

--- a/src/Bonsai.Gui/CheckBoxVisualizer.cs
+++ b/src/Bonsai.Gui/CheckBoxVisualizer.cs
@@ -16,7 +16,6 @@ namespace Bonsai.Gui
             checkBox.Dock = DockStyle.Fill;
             checkBox.Size = new Size(300, 75);
             checkBox.Checked = builder.Checked;
-            checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
             checkBox.SubscribeTo(builder._Checked, value => checkBox.Checked = value);
             checkBox.CheckedChanged += (sender, e) =>
             {

--- a/src/Bonsai.Gui/CheckButtonBuilderBase.cs
+++ b/src/Bonsai.Gui/CheckButtonBuilderBase.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides an abstract base class with common check button control functionality.
+    /// </summary>
+    public class CheckButtonBuilderBase : ButtonBuilderBase<bool>
+    {
+        internal readonly BehaviorSubject<bool> _Checked = new(false);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the button is checked.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Indicates whether the button is checked.")]
+        public bool Checked
+        {
+            get => _Checked.Value;
+            set => _Checked.OnNext(value);
+        }
+
+        /// <inheritdoc/>
+        protected override IObservable<bool> Generate()
+        {
+            return _Checked;
+        }
+    }
+}

--- a/src/Bonsai.Gui/ControlExtensions.cs
+++ b/src/Bonsai.Gui/ControlExtensions.cs
@@ -85,6 +85,11 @@ namespace Bonsai.Gui
                 control.SubscribeTo(controlBuilder._Visible, value => control.Visible = value);
                 control.SubscribeTo(controlBuilder._Font, value => control.Font = value);
             }
+
+            if (builder is TextControlBuilderBase textControlBuilder)
+            {
+                control.SubscribeTo(textControlBuilder._Text, value => control.Text = value);
+            }
         }
     }
 }

--- a/src/Bonsai.Gui/GroupBoxVisualizer.cs
+++ b/src/Bonsai.Gui/GroupBoxVisualizer.cs
@@ -27,7 +27,6 @@ namespace Bonsai.Gui
             var groupBox = new GroupBox();
             groupBox.Dock = DockStyle.Fill;
             groupBox.Size = new Size(320, 240);
-            groupBox.SubscribeTo(builder._Text, value => groupBox.Text = value);
             return groupBox;
         }
     }

--- a/src/Bonsai.Gui/RadioButtonBuilder.cs
+++ b/src/Bonsai.Gui/RadioButtonBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Reactive.Subjects;
+﻿using System.ComponentModel;
 
 namespace Bonsai.Gui
 {
@@ -10,21 +8,7 @@ namespace Bonsai.Gui
     /// </summary>
     [TypeVisualizer(typeof(RadioButtonVisualizer))]
     [Description("Interfaces with a radio button control and generates a sequence of notifications whenever the checked status changes.")]
-    public class RadioButtonBuilder : ButtonBuilderBase<bool>
+    public class RadioButtonBuilder : CheckButtonBuilderBase
     {
-        internal readonly Subject<bool> _CheckedChanged = new();
-
-        /// <summary>
-        /// Gets or sets a value specifying the initial state of the radio button.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies the initial state of the radio button.")]
-        public bool Checked { get; set; }
-
-        /// <inheritdoc/>
-        protected override IObservable<bool> Generate()
-        {
-            return _CheckedChanged;
-        }
     }
 }

--- a/src/Bonsai.Gui/RadioButtonVisualizer.cs
+++ b/src/Bonsai.Gui/RadioButtonVisualizer.cs
@@ -16,7 +16,6 @@ namespace Bonsai.Gui
             radioButton.Dock = DockStyle.Fill;
             radioButton.Size = new Size(300, 75);
             radioButton.Checked = builder.Checked;
-            radioButton.SubscribeTo(builder._Text, value => radioButton.Text = value);
             radioButton.SubscribeTo(builder._Checked, value => radioButton.Checked = value);
             radioButton.CheckedChanged += (sender, e) =>
             {

--- a/src/Bonsai.Gui/RadioButtonVisualizer.cs
+++ b/src/Bonsai.Gui/RadioButtonVisualizer.cs
@@ -17,9 +17,10 @@ namespace Bonsai.Gui
             radioButton.Size = new Size(300, 75);
             radioButton.Checked = builder.Checked;
             radioButton.SubscribeTo(builder._Text, value => radioButton.Text = value);
+            radioButton.SubscribeTo(builder._Checked, value => radioButton.Checked = value);
             radioButton.CheckedChanged += (sender, e) =>
             {
-                builder._CheckedChanged.OnNext(radioButton.Checked);
+                builder._Checked.OnNext(radioButton.Checked);
             };
             return radioButton;
         }

--- a/src/Bonsai.Gui/TextControlBuilderBase.cs
+++ b/src/Bonsai.Gui/TextControlBuilderBase.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
 using System.Reactive.Subjects;
 
 namespace Bonsai.Gui
@@ -21,5 +24,29 @@ namespace Bonsai.Gui
             get => _Text.Value;
             set => _Text.OnNext(value);
         }
+    }
+
+    /// <summary>
+    /// Provides an abstract base class with common UI text and event source control functionality.
+    /// </summary>
+    /// <typeparam name="TEvent">The type of event notifications emitted by the UI control.</typeparam>
+    public abstract class TextControlBuilderBase<TEvent> : TextControlBuilderBase, INamedElement
+    {
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the UI control.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return Expression.Call(Expression.Constant(this), nameof(Generate), null);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of event notifications from the UI control.
+        /// </summary>
+        /// <returns>
+        /// An observable sequence of events of type <typeparamref name="TEvent"/>.
+        /// </returns>
+        protected abstract IObservable<TEvent> Generate();
     }
 }

--- a/src/Bonsai.Gui/ToggleButtonBuilder.cs
+++ b/src/Bonsai.Gui/ToggleButtonBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.ComponentModel;
-using System.Reactive.Subjects;
+﻿using System.ComponentModel;
 
 namespace Bonsai.Gui
 {
@@ -10,14 +8,7 @@ namespace Bonsai.Gui
     /// </summary>
     [TypeVisualizer(typeof(ToggleButtonVisualizer))]
     [Description("Interfaces with a toggle button control and generates a sequence of notifications whenever the toggle status changes.")]
-    public class ToggleButtonBuilder : ButtonBuilderBase<bool>
+    public class ToggleButtonBuilder : CheckButtonBuilderBase
     {
-        internal readonly Subject<bool> _CheckedChanged = new();
-
-        /// <inheritdoc/>
-        protected override IObservable<bool> Generate()
-        {
-            return _CheckedChanged;
-        }
     }
 }

--- a/src/Bonsai.Gui/ToggleButtonVisualizer.cs
+++ b/src/Bonsai.Gui/ToggleButtonVisualizer.cs
@@ -17,7 +17,6 @@ namespace Bonsai.Gui
             checkBox.Size = new Size(300, 150);
             checkBox.Appearance = Appearance.Button;
             checkBox.TextAlign = ContentAlignment.MiddleCenter;
-            checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
             checkBox.SubscribeTo(builder._Checked, value => checkBox.Checked = value);
             checkBox.CheckedChanged += (sender, e) =>
             {

--- a/src/Bonsai.Gui/ToggleButtonVisualizer.cs
+++ b/src/Bonsai.Gui/ToggleButtonVisualizer.cs
@@ -18,9 +18,10 @@ namespace Bonsai.Gui
             checkBox.Appearance = Appearance.Button;
             checkBox.TextAlign = ContentAlignment.MiddleCenter;
             checkBox.SubscribeTo(builder._Text, value => checkBox.Text = value);
+            checkBox.SubscribeTo(builder._Checked, value => checkBox.Checked = value);
             checkBox.CheckedChanged += (sender, e) =>
             {
-                builder._CheckedChanged.OnNext(checkBox.Checked);
+                builder._Checked.OnNext(checkBox.Checked);
             };
             return checkBox;
         }


### PR DESCRIPTION
This PR introduces two way binding between view and view-model state for check-box button style controls in the package, i.e. in this case the `Checked` property. In general the same pattern will be followed for all other controls with state.

Almost all primitive controls are concerned with managing a single piece of state, and we want any changes in this state to be propagated as an observable sequence. To allow two way binding we replaced the UI change event source with a `BehaviorSubject` that is responsible for storing the state. Apart from signaling all changes, this subject can also be used as a binding source by the UI control, so that any external changes to the state are automatically reflected in the UI. Finally, the state is exposed through a configurable property which can be externalized in the workflow.

Aside from two way binding, this allows for state to persist between opening and closing of visualizer windows, and also for dynamically changing the state using other workflow inputs by externalizing and mapping the state property.