### PR TITLE
Add label and text box controls

### DIFF
--- a/src/Bonsai.Gui/LabelBuilder.cs
+++ b/src/Bonsai.Gui/LabelBuilder.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a label control.
+    /// </summary>
+    [TypeVisualizer(typeof(LabelVisualizer))]
+    [Description("Interfaces with a label control.")]
+    public class LabelBuilder : TextControlBuilderBase
+    {
+    }
+}

--- a/src/Bonsai.Gui/LabelVisualizer.cs
+++ b/src/Bonsai.Gui/LabelVisualizer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a label control.
+    /// </summary>
+    public class LabelVisualizer : ControlVisualizerBase<Label, LabelBuilder>
+    {
+        /// <inheritdoc/>
+        protected override Label CreateControl(IServiceProvider provider, LabelBuilder builder)
+        {
+            var label = new Label();
+            label.Dock = DockStyle.Fill;
+            label.Size = new Size(300, label.Height);
+            return label;
+        }
+    }
+}

--- a/src/Bonsai.Gui/TextBoxBuilder.cs
+++ b/src/Bonsai.Gui/TextBoxBuilder.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a text box control and generates
+    /// a sequence of notifications whenever the text changes.
+    /// </summary>
+    [TypeVisualizer(typeof(TextBoxVisualizer))]
+    public class TextBoxBuilder : TextControlBuilderBase<string>
+    {
+        internal readonly BehaviorSubject<bool> _Multiline = new(true);
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the text box is multiline.
+        /// </summary>
+        [Description("Specifies whether the text box is multiline.")]
+        public bool Multiline
+        {
+            get => _Multiline.Value;
+            set => _Multiline.OnNext(value);
+        }
+
+        /// <summary>
+        /// Generates an observable sequence of values containing the contents
+        /// of the text box whenever the text changes.
+        /// </summary>
+        /// <returns>
+        /// A sequence of <see cref="string"/> values representing the contents
+        /// of the text box.
+        /// </returns>
+        protected override IObservable<string> Generate()
+        {
+            return _Text;
+        }
+    }
+}

--- a/src/Bonsai.Gui/TextBoxVisualizer.cs
+++ b/src/Bonsai.Gui/TextBoxVisualizer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a text box control.
+    /// </summary>
+    public class TextBoxVisualizer : ControlVisualizerBase<TextBox, TextBoxBuilder>
+    {
+        /// <inheritdoc/>
+        protected override TextBox CreateControl(IServiceProvider provider, TextBoxBuilder builder)
+        {
+            var textBox = new TextBox();
+            textBox.Dock = DockStyle.Fill;
+            textBox.Multiline = builder._Multiline.Value;
+            if (textBox.Multiline)
+            {
+                textBox.Size = new Size(320, 240);
+            }
+
+            textBox.SubscribeTo(builder._Multiline, value => textBox.Multiline = value);
+            textBox.TextChanged += (sender, e) =>
+            {
+                builder._Text.OnNext(textBox.Text);
+            };
+            return textBox;
+        }
+    }
+}

--- a/src/Bonsai.Gui/TextBoxVisualizer.cs
+++ b/src/Bonsai.Gui/TextBoxVisualizer.cs
@@ -20,6 +20,7 @@ namespace Bonsai.Gui
                 textBox.Size = new Size(320, 240);
             }
 
+            textBox.Text = builder._Text.Value;
             textBox.SubscribeTo(builder._Multiline, value => textBox.Multiline = value);
             textBox.TextChanged += (sender, e) =>
             {


### PR DESCRIPTION
This PR adds support for the following common controls:

- `Label` (display simple text)
- `TextBox` (simple text input control)

In the case of `TextBox`, a notification is sent every time the text changes.