### PR TITLE
Add property grid control

### DIFF
--- a/src/Bonsai.Gui/PropertyGridBuilder.cs
+++ b/src/Bonsai.Gui/PropertyGridBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel;
+using System.Reactive.Subjects;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Represents an operator that interfaces with a property grid control for
+    /// browsing the properties of the workflow in which it is inserted.
+    /// </summary>
+    [TypeVisualizer(typeof(PropertyGridVisualizer))]
+    [Description("Interfaces with a property grid control for browsing the properties of the workflow in which it is inserted.")]
+    public class PropertyGridBuilder : ControlBuilderBase
+    {
+        internal readonly BehaviorSubject<bool> _HelpVisible = new(true);
+        internal readonly BehaviorSubject<bool> _ToolbarVisible = new(true);
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the help text box is visible.
+        /// </summary>
+        [Description("Specifies whether the help text box is visible.")]
+        public bool HelpVisible
+        {
+            get => _HelpVisible.Value;
+            set => _HelpVisible.OnNext(value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the toolbar is visible.
+        /// </summary>
+        [Description("Specifies whether the toolbar is visible.")]
+        public bool ToolbarVisible
+        {
+            get => _ToolbarVisible.Value;
+            set => _ToolbarVisible.OnNext(value);
+        }
+    }
+}

--- a/src/Bonsai.Gui/PropertyGridBuilder.cs
+++ b/src/Bonsai.Gui/PropertyGridBuilder.cs
@@ -17,6 +17,7 @@ namespace Bonsai.Gui
         /// <summary>
         /// Gets or sets a value specifying whether the help text box is visible.
         /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
         [Description("Specifies whether the help text box is visible.")]
         public bool HelpVisible
         {
@@ -27,6 +28,7 @@ namespace Bonsai.Gui
         /// <summary>
         /// Gets or sets a value specifying whether the toolbar is visible.
         /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
         [Description("Specifies whether the toolbar is visible.")]
         public bool ToolbarVisible
         {

--- a/src/Bonsai.Gui/PropertyGridVisualizer.cs
+++ b/src/Bonsai.Gui/PropertyGridVisualizer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using Bonsai.Expressions;
+using PropertyGrid = Bonsai.Design.PropertyGrid;
+
+namespace Bonsai.Gui
+{
+    /// <summary>
+    /// Provides a type visualizer representing a property grid control.
+    /// </summary>
+    public class PropertyGridVisualizer : ControlVisualizerBase<PropertyGrid, PropertyGridBuilder>
+    {
+        /// <inheritdoc/>
+        protected override PropertyGrid CreateControl(IServiceProvider provider, PropertyGridBuilder builder)
+        {
+            var propertyGrid = new PropertyGrid();
+            propertyGrid.Dock = DockStyle.Fill;
+            propertyGrid.Size = new Size(350, 450);
+            propertyGrid.Site = new ServiceProviderContext(provider);
+            propertyGrid.SubscribeTo(builder._HelpVisible, value => propertyGrid.HelpVisible = value);
+            propertyGrid.SubscribeTo(builder._ToolbarVisible, value => propertyGrid.ToolbarVisible = value);
+
+            var workflowBuilder = (WorkflowBuilder)provider.GetService(typeof(WorkflowBuilder));
+            propertyGrid.SelectedObject = GetExpressionContext(workflowBuilder.Workflow, builder);
+            return propertyGrid;
+        }
+
+        static ExpressionBuilderGraph GetExpressionContext(ExpressionBuilderGraph source, ExpressionBuilder target)
+        {
+            foreach (var element in source.Elements())
+            {
+                if (element == target) return source;
+                if (element is IWorkflowExpressionBuilder workflowBuilder)
+                {
+                    var nestedContext = GetExpressionContext(workflowBuilder.Workflow, target);
+                    if (nestedContext != null)
+                    {
+                        return nestedContext;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        class ServiceProviderContext : ISite
+        {
+            readonly IServiceProvider parentProvider;
+
+            public ServiceProviderContext(IServiceProvider provider)
+            {
+                parentProvider = provider;
+            }
+
+            public IComponent Component => null;
+
+            public IContainer Container => null;
+
+            public bool DesignMode => false;
+
+            public string Name { get; set; }
+
+            public object GetService(Type serviceType)
+            {
+                return parentProvider?.GetService(serviceType);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui/TextBoxBuilder.cs
+++ b/src/Bonsai.Gui/TextBoxBuilder.cs
@@ -9,6 +9,7 @@ namespace Bonsai.Gui
     /// a sequence of notifications whenever the text changes.
     /// </summary>
     [TypeVisualizer(typeof(TextBoxVisualizer))]
+    [Description("Interfaces with a text box control and generates a sequence of notifications whenever the text changes.")]
     public class TextBoxBuilder : TextControlBuilderBase<string>
     {
         internal readonly BehaviorSubject<bool> _Multiline = new(true);


### PR DESCRIPTION
This PR adds support for a `PropertyGrid` control where the displayed properties are taken from all externalized properties in the workflow level at which the operator is placed. This allows for a flexible configuration of property elements to display. Service providers are routed to ensure editing experience is identical to the main editor property grid.