### PR TITLE
Split visualizers into separate package

### DIFF
--- a/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj
+++ b/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <Title>Bonsai - GUI Visualizers</Title>
+    <Description>Bonsai Library for composing real-time data visualizers.</Description>
+    <PackageTags>Bonsai Rx GUI Graphical User Interface Visualizers</PackageTags>
+    <TargetFrameworks>net472</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
+    <VersionPrefix>0.1.0</VersionPrefix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ZedGraph" Version="5.1.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Gui\Bonsai.Gui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Bonsai.Gui.Visualizers/GraphControl.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphControl.cs
@@ -8,7 +8,7 @@ using System.Reactive.Linq;
 using System.Reactive.Disposables;
 using Bonsai.Design;
 
-namespace Bonsai.Gui
+namespace Bonsai.Gui.Visualizers
 {
     /// <summary>
     /// Provides a dynamic graph control with a built-in color cycle palette.

--- a/src/Bonsai.Gui.Visualizers/Properties/launchSettings.json
+++ b/src/Bonsai.Gui.Visualizers/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:\"$(TargetDir).\"",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/src/Bonsai.Gui.sln
+++ b/src/Bonsai.Gui.sln
@@ -3,7 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Gui", "Bonsai.Gui\Bonsai.Gui.csproj", "{B9678B9E-B8CE-4A70-B04D-E154392279E1}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1A905738-1AF3-436A-985D-11460669E207}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bonsai.Gui", "Bonsai.Gui\Bonsai.Gui.csproj", "{B9678B9E-B8CE-4A70-B04D-E154392279E1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Gui.Visualizers", "Bonsai.Gui.Visualizers\Bonsai.Gui.Visualizers.csproj", "{FDBC57F0-B0D6-4CA3-B733-79F4421526D6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +22,10 @@ Global
 		{B9678B9E-B8CE-4A70-B04D-E154392279E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9678B9E-B8CE-4A70-B04D-E154392279E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9678B9E-B8CE-4A70-B04D-E154392279E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDBC57F0-B0D6-4CA3-B733-79F4421526D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDBC57F0-B0D6-4CA3-B733-79F4421526D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDBC57F0-B0D6-4CA3-B733-79F4421526D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDBC57F0-B0D6-4CA3-B733-79F4421526D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Bonsai.Gui/Bonsai.Gui.csproj
+++ b/src/Bonsai.Gui/Bonsai.Gui.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Title>Bonsai - GUI</Title>
-    <Description>Bonsai Library for composing user interfaces and real-time graphs.</Description>
-    <PackageTags>Bonsai Rx GUI Graphical User Interface Visualizers</PackageTags>
+    <Description>Bonsai Library for composing reactive user interfaces.</Description>
+    <PackageTags>Bonsai Rx GUI Graphical User Interface</PackageTags>
     <TargetFrameworks>net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <VersionPrefix>0.1.0</VersionPrefix>
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Design" Version="2.8.0" />
-    <PackageReference Include="ZedGraph" Version="5.1.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/ContainerControlVisualizerBase.cs
@@ -29,14 +29,10 @@ namespace Bonsai.Gui
         protected abstract void AddControl(int index, Control control);
 
         /// <inheritdoc/>
-        public override void LoadMashups(IServiceProvider provider)
+        protected override void LoadMashupSource(int index, MashupSource mashupSource, IServiceProvider provider)
         {
-            for (int i = 0; i < MashupSources.Count; i++)
-            {
-                var mashupSource = MashupSources[i];
-                var containerProvider = new ContainerControlServiceProvider(i, this, mashupSource.Source, provider);
-                mashupSource.Visualizer.Load(containerProvider);
-            }
+            var containerProvider = new ContainerControlServiceProvider(index, this, mashupSource.Source, provider);
+            mashupSource.Visualizer.Load(containerProvider);
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui/MashupControlVisualizerBase.cs
+++ b/src/Bonsai.Gui/MashupControlVisualizerBase.cs
@@ -66,9 +66,24 @@ namespace Bonsai.Gui
             for (int i = 0; i < MashupSources.Count; i++)
             {
                 var mashupSource = MashupSources[i];
-                var mashupServiceProvider = new MashupControlServiceProvider(i, this, mashupSource.Source, provider);
-                mashupSource.Visualizer.Load(mashupServiceProvider);
+                LoadMashupSource(i, mashupSource, provider);
             }
+        }
+
+        /// <summary>
+        /// Loads type visualizer resources for an individual mashup source in the
+        /// mashup visualizer.
+        /// </summary>
+        /// <param name="index">The zero-based index of the mashup source.</param>
+        /// <param name="mashupSource">The mashup source for which to load visualizer resources.</param>
+        /// <param name="provider">
+        /// A service provider object which can be used to obtain visualization,
+        /// runtime inspection, or other editing services.
+        /// </param>
+        protected virtual void LoadMashupSource(int index, MashupSource mashupSource, IServiceProvider provider)
+        {
+            var mashupServiceProvider = new MashupControlServiceProvider(index, this, mashupSource.Source, provider);
+            mashupSource.Visualizer.Load(mashupServiceProvider);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR introduces a new `Bonsai.Gui.Visualizers` package which will contain reusable and composable type visualizers. Most real-time visualizers depend on `ZedGraph` and this package is also intended to help isolate that dependency.