### PR TITLE
Add support for composing bar and rolling graphs in a single panel

### DIFF
--- a/src/Bonsai.Gui.Visualizers/BarGraph.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraph.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    class BarGraph : RollingGraph
+    {
+        public BarBase BaseAxis
+        {
+            get { return GraphPane.BarSettings.Base; }
+            set { GraphPane.BarSettings.Base = value; }
+        }
+
+        public BarType BarType
+        {
+            get { return GraphPane.BarSettings.Type; }
+            set { GraphPane.BarSettings.Type = value; }
+        }
+
+        internal override CurveItem CreateSeries(string label, IPointListEdit points, Color color)
+        {
+            var curve = new BarItem(label, points, color);
+            curve.Label.IsVisible = !string.IsNullOrEmpty(label);
+            curve.Bar.Fill.Type = FillType.Solid;
+            curve.Bar.Border.IsVisible = false;
+            return curve;
+        }
+
+        static int FindIndex(IPointListEdit series, string tag)
+        {
+            if (!string.IsNullOrEmpty(tag))
+            {
+                for (int i = 0; i < series.Count; i++)
+                {
+                    if (EqualityComparer<string>.Default.Equals(tag, (string)series[i].Tag))
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        public void AddValues(double index, string tag, double[] values)
+        {
+            if (values.Length > 0)
+            {
+                var updateIndex = FindIndex(Series[0], tag);
+                if (updateIndex >= 0 && BaseAxis <= BarBase.X2) UpdateLastBaseX();
+                else if (updateIndex >= 0) UpdateLastBaseY();
+                else if (BaseAxis <= BarBase.X2) AddBaseX();
+                else AddBaseY();
+
+                void UpdateLastBaseX()
+                {
+                    for (int i = 0; i < Series.Length; i++)
+                        Series[i][updateIndex].Y = values[i];
+                }
+
+                void UpdateLastBaseY()
+                {
+                    for (int i = 0; i < Series.Length; i++)
+                        Series[i][updateIndex].X = values[i];
+                }
+
+                void AddBaseX()
+                {
+                    for (int i = 0; i < Series.Length; i++)
+                        Series[i].Add(new PointPair(index, values[i], tag));
+                }
+
+                void AddBaseY()
+                {
+                    for (int i = 0; i < Series.Length; i++)
+                        Series[i].Add(new PointPair(values[i], index, tag));
+                }
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraph.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraph.cs
@@ -43,11 +43,11 @@ namespace Bonsai.Gui.Visualizers
             return -1;
         }
 
-        public void AddValues(double index, string tag, double[] values)
+        public new void AddValues(double index, string label, double[] values)
         {
             if (values.Length > 0)
             {
-                var updateIndex = FindIndex(Series[0], tag);
+                var updateIndex = FindIndex(Series[0], label);
                 if (updateIndex >= 0 && BaseAxis <= BarBase.X2) UpdateLastBaseX();
                 else if (updateIndex >= 0) UpdateLastBaseY();
                 else if (BaseAxis <= BarBase.X2) AddBaseX();
@@ -68,13 +68,13 @@ namespace Bonsai.Gui.Visualizers
                 void AddBaseX()
                 {
                     for (int i = 0; i < Series.Length; i++)
-                        Series[i].Add(new PointPair(index, values[i], tag));
+                        Series[i].Add(index, values[i], label);
                 }
 
                 void AddBaseY()
                 {
                     for (int i = 0; i < Series.Length; i++)
-                        Series[i].Add(new PointPair(values[i], index, tag));
+                        Series[i].Add(values[i], index, label);
                 }
             }
         }

--- a/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
@@ -1,0 +1,152 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that configures a visualizer to plot each element
+    /// of the sequence as a bar graph.
+    /// </summary>
+    [DefaultProperty(nameof(ValueSelector))]
+    [TypeVisualizer(typeof(BarGraphVisualizer))]
+    [Description("A visualizer that plots each element of the sequence as a bar graph.")]
+    public class BarGraphBuilder : SingleArgumentExpressionBuilder
+    {
+        /// <summary>
+        /// Gets or sets the name of the property that will be used as index for the graph.
+        /// </summary>
+        [Editor("Bonsai.Design.MemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The name of the property that will be used as index for the graph.")]
+        public string IndexSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the names of the properties that will be displayed in the graph.
+        /// </summary>
+        [Editor("Bonsai.Design.MultiMemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The names of the properties that will be displayed in the graph.")]
+        public string ValueSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the axis on which the bars in the graph will be displayed.
+        /// </summary>
+        [TypeConverter(typeof(BaseAxisConverter))]
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies the axis on which the bars in the graph will be displayed.")]
+        public BarBase BaseAxis { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying how the different bars in the graph will be visually arranged.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies how the different bars in the graph will be visually arranged.")]
+        public BarType BarType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional capacity used for rolling bar graphs. If no capacity is specified,
+        /// all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional capacity used for rolling bar graphs. If no capacity is specified, all data points will be displayed.")]
+        public int? Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        public double? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        public double? Max { get; set; }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal int? Capacity;
+            internal double? Min;
+            internal double? Max;
+            internal Type IndexType;
+            internal string IndexLabel;
+            internal string[] ValueLabels;
+            internal Action<object, IBarGraphVisualizer> AddValues;
+            internal BarBase BaseAxis;
+            internal BarType BarType;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// bar graph visualizer on the specified input argument.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var parameterType = source.Type.GetGenericArguments()[0];
+            var valueParameter = Expression.Parameter(typeof(object));
+            var viewParameter = Expression.Parameter(typeof(IBarGraphVisualizer));
+            var elementVariable = Expression.Variable(parameterType);
+            Controller = new VisualizerController
+            {
+                Capacity = Capacity,
+                Min = Min,
+                Max = Max,
+                BaseAxis = BaseAxis,
+                BarType = BarType
+            };
+
+            var selectedIndex = GraphHelper.SelectIndexMember(elementVariable, IndexSelector, out Controller.IndexLabel);
+            Controller.IndexType = selectedIndex.Type;
+            if (selectedIndex.Type != typeof(double) && selectedIndex.Type != typeof(string))
+            {
+                selectedIndex = Expression.Convert(selectedIndex, typeof(double));
+            }
+
+            var selectedValues = GraphHelper.SelectDataValues(elementVariable, ValueSelector, out Controller.ValueLabels);
+            var addValuesBody = Expression.Block(new[] { elementVariable },
+                Expression.Assign(elementVariable, Expression.Convert(valueParameter, parameterType)),
+                Expression.Call(viewParameter, nameof(IBarGraphVisualizer.AddValues), null, selectedIndex, selectedValues));
+            Controller.AddValues = Expression.Lambda<Action<object, IBarGraphVisualizer>>(addValuesBody, valueParameter, viewParameter).Compile();
+            return Expression.Call(typeof(BarGraphBuilder), nameof(Process), new[] { parameterType }, source);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source;
+        }
+    }
+
+    class BaseAxisConverter : EnumConverter
+    {
+        public BaseAxisConverter(Type type)
+            : base(type)
+        {
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            return new StandardValuesCollection(new[] { BarBase.X, BarBase.Y });
+        }
+    }
+
+    interface IBarGraphVisualizer
+    {
+        void AddValues(string index, params double[] values);
+
+        void AddValues(double index, params double[] values);
+
+        void AddValues(double index, string tag, params double[] values);
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
@@ -63,19 +63,19 @@ namespace Bonsai.Gui.Visualizers
         public int? Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed lower limit for the bar range axis.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        [Description("Specifies the optional fixed lower limit for the bar range axis.")]
         public double? Min { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed upper limit for the bar range axis.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        [Description("Specifies the optional fixed upper limit for the bar range axis.")]
         public double? Max { get; set; }
 
         internal VisualizerController Controller { get; set; }

--- a/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphBuilder.cs
@@ -48,6 +48,13 @@ namespace Bonsai.Gui.Visualizers
         public BarType BarType { get; set; }
 
         /// <summary>
+        /// Gets the optional settings for each bar added to the graph.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies optional settings for each bar added to the graph.")]
+        public Collection<CurveConfiguration> CurveSettings { get; } = new();
+
+        /// <summary>
         /// Gets or sets the optional capacity used for rolling bar graphs. If no capacity is specified,
         /// all data points will be displayed.
         /// </summary>
@@ -81,6 +88,7 @@ namespace Bonsai.Gui.Visualizers
             internal Type IndexType;
             internal string IndexLabel;
             internal string[] ValueLabels;
+            internal CurveConfiguration[] CurveSettings;
             internal Action<object, IBarGraphVisualizer> AddValues;
             internal BarBase BaseAxis;
             internal BarType BarType;
@@ -104,7 +112,8 @@ namespace Bonsai.Gui.Visualizers
                 Min = Min,
                 Max = Max,
                 BaseAxis = BaseAxis,
-                BarType = BarType
+                BarType = BarType,
+                CurveSettings = CurveSettings.ToArray()
             };
 
             var selectedIndex = GraphHelper.SelectIndexMember(elementVariable, IndexSelector, out Controller.IndexLabel);

--- a/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Reactive;
+using Bonsai;
+using Bonsai.Design;
+using Bonsai.Gui.Visualizers;
+using Bonsai.Expressions;
+using ZedGraph;
+
+[assembly: TypeVisualizer(typeof(BarGraphOverlay), Target = typeof(MashupSource<GraphPanelVisualizer, BarGraphVisualizer>))]
+
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer used to overlay a sequence of values as a bar graph.
+    /// </summary>
+    public class BarGraphOverlay : BufferedVisualizer, IBarGraphVisualizer
+    {
+        GraphPanelVisualizer visualizer;
+        BarGraphBuilder.VisualizerController controller;
+        IPointListEdit[] series;
+
+        void IBarGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
+
+        void IBarGraphVisualizer.AddValues(double index, params double[] values) => AddValues(index, null, values);
+
+        void IBarGraphVisualizer.AddValues(double index, string tag, params double[] values) => AddValues(index, tag, values);
+
+        static int FindIndex(IPointListEdit series, string tag)
+        {
+            if (!string.IsNullOrEmpty(tag))
+            {
+                for (int i = 0; i < series.Count; i++)
+                {
+                    if (EqualityComparer<string>.Default.Equals(tag, (string)series[i].Tag))
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        internal void AddValues(double index, string tag, params double[] values)
+        {
+            if (values.Length > 0)
+            {
+                var updateIndex = FindIndex(series[0], tag);
+                if (updateIndex >= 0 && controller.BaseAxis <= BarBase.X2) UpdateLastBaseX();
+                else if (updateIndex >= 0) UpdateLastBaseY();
+                else if (controller.BaseAxis <= BarBase.X2) AddBaseX();
+                else AddBaseY();
+
+                void UpdateLastBaseX()
+                {
+                    for (int i = 0; i < series.Length; i++)
+                        series[i][updateIndex].Y = values[i];
+                }
+
+                void UpdateLastBaseY()
+                {
+                    for (int i = 0; i < series.Length; i++)
+                        series[i][updateIndex].X = values[i];
+                }
+
+                void AddBaseX()
+                {
+                    for (int i = 0; i < series.Length; i++)
+                        series[i].Add(new PointPair(index, values[i], tag));
+                }
+
+                void AddBaseY()
+                {
+                    for (int i = 0; i < series.Length; i++)
+                        series[i].Add(new PointPair(values[i], index, tag));
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            visualizer = (GraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var barGraphBuilder = (BarGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = barGraphBuilder.Controller;
+            visualizer.EnsureBarSettings(new BarSettings(visualizer.Control.GraphPane)
+            {
+                Base = controller.BaseAxis,
+                Type = controller.BarType
+            });
+            visualizer.EnsureIndex(controller.IndexType);
+
+            var hasLabels = controller.ValueLabels != null;
+            if (hasLabels)
+            {
+                series = new IPointListEdit[controller.ValueLabels.Length];
+                for (int i = 0; i < series.Length; i++)
+                {
+                    series[i] = new PointPairList();
+                    var curveSettings = controller.CurveSettings.Length > 0
+                        ? controller.CurveSettings[i % controller.CurveSettings.Length]
+                        : null;
+                    var color = curveSettings?.Color.IsEmpty == false
+                        ? curveSettings.Color
+                        : visualizer.Control.GetNextColor();
+                    var curve = CreateSeries(curveSettings?.Label ?? controller.ValueLabels[i], series[i], color);
+                    visualizer.Control.GraphPane.CurveList.Add(curve);
+                }
+            }
+        }
+
+        private CurveItem CreateSeries(string label, IPointListEdit points, Color color)
+        {
+            var curve = new BarItem(label, points, color);
+            curve.Label.IsVisible = !string.IsNullOrEmpty(label);
+            curve.Bar.Fill.Type = FillType.Solid;
+            curve.Bar.Border.IsVisible = false;
+            return curve;
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
+            {
+                visualizer.Control.Invalidate();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(value, this);
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            visualizer = null;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
@@ -20,7 +20,7 @@ namespace Bonsai.Gui.Visualizers
     {
         GraphPanelVisualizer visualizer;
         BarGraphBuilder.VisualizerController controller;
-        IPointListEdit[] series;
+        BoundedPointPairList[] series;
 
         void IBarGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
 
@@ -69,13 +69,13 @@ namespace Bonsai.Gui.Visualizers
                 void AddBaseX()
                 {
                     for (int i = 0; i < series.Length; i++)
-                        series[i].Add(new PointPair(index, values[i], tag));
+                        series[i].Add(index, values[i], index, tag);
                 }
 
                 void AddBaseY()
                 {
                     for (int i = 0; i < series.Length; i++)
-                        series[i].Add(new PointPair(values[i], index, tag));
+                        series[i].Add(values[i], index, index, tag);
                 }
             }
         }
@@ -97,10 +97,10 @@ namespace Bonsai.Gui.Visualizers
             var hasLabels = controller.ValueLabels != null;
             if (hasLabels)
             {
-                series = new IPointListEdit[controller.ValueLabels.Length];
+                series = new BoundedPointPairList[controller.ValueLabels.Length];
                 for (int i = 0; i < series.Length; i++)
                 {
-                    series[i] = new PointPairList();
+                    series[i] = new BoundedPointPairList();
                     var curveSettings = controller.CurveSettings.Length > 0
                         ? controller.CurveSettings[i % controller.CurveSettings.Length]
                         : null;

--- a/src/Bonsai.Gui.Visualizers/BarGraphView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphView.Designer.cs
@@ -1,0 +1,155 @@
+﻿namespace Bonsai.Gui.Visualizers
+{
+    partial class BarGraphView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButton = new System.Windows.Forms.ToolStripButton();
+            this.graph = new Bonsai.Gui.Visualizers.BarGraph();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.capacityStatusLabel,
+            this.capacityValueLabel,
+            this.scaleStatusLabel,
+            this.minStatusLabel,
+            this.maxStatusLabel,
+            this.autoScaleButton});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip1";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // capacityStatusLabel
+            // 
+            this.capacityStatusLabel.Name = "capacityStatusLabel";
+            this.capacityStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.capacityStatusLabel.Text = "Capacity:";
+            // 
+            // capacityValueLabel
+            // 
+            this.capacityValueLabel.Name = "capacityValueLabel";
+            this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.capacityValueLabel.Text = "count";
+            // 
+            // scaleStatusLabel
+            // 
+            this.scaleStatusLabel.Name = "scaleStatusLabel";
+            this.scaleStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabel.Text = "Scale:";
+            // 
+            // minStatusLabel
+            // 
+            this.minStatusLabel.Name = "minStatusLabel";
+            this.minStatusLabel.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabel.Text = "min";
+            this.minStatusLabel.Visible = false;
+            // 
+            // maxStatusLabel
+            // 
+            this.maxStatusLabel.Name = "maxStatusLabel";
+            this.maxStatusLabel.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabel.Text = "Max";
+            this.maxStatusLabel.Visible = false;
+            // 
+            // autoScaleButton
+            // 
+            this.autoScaleButton.Checked = true;
+            this.autoScaleButton.CheckOnClick = true;
+            this.autoScaleButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButton.Name = "autoScaleButton";
+            this.autoScaleButton.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButton.Text = "auto";
+            this.autoScaleButton.CheckedChanged += new System.EventHandler(this.autoScaleButton_CheckedChanged);
+            // 
+            // graph
+            // 
+            this.graph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.graph.Location = new System.Drawing.Point(0, 0);
+            this.graph.Name = "graph";
+            this.graph.ScrollGrace = 0D;
+            this.graph.ScrollMaxX = 0D;
+            this.graph.ScrollMaxY = 0D;
+            this.graph.ScrollMaxY2 = 0D;
+            this.graph.ScrollMinX = 0D;
+            this.graph.ScrollMinY = 0D;
+            this.graph.ScrollMinY2 = 0D;
+            this.graph.Size = new System.Drawing.Size(400, 218);
+            this.graph.TabIndex = 2;
+            this.graph.MouseMoveEvent += new ZedGraph.ZedGraphControl.ZedMouseEventHandler(this.graph_MouseMoveEvent);
+            this.graph.MouseClick += new System.Windows.Forms.MouseEventHandler(this.graph_MouseClick);
+            // 
+            // BarGraphView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.graph);
+            this.Controls.Add(this.statusStrip);
+            this.Name = "BarGraphView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripButton autoScaleButton;
+        private BarGraph graph;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraphView.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphView.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+using System.Globalization;
+
+namespace Bonsai.Gui.Visualizers
+{
+    partial class BarGraphView : UserControl
+    {
+        readonly ToolStripEditableLabel minEditableLabel;
+        readonly ToolStripEditableLabel maxEditableLabel;
+        readonly ToolStripEditableLabel capacityEditableLabel;
+
+        public BarGraphView()
+        {
+            InitializeComponent();
+            autoScaleButton.Checked = true;
+            capacityEditableLabel = new ToolStripEditableLabel(capacityValueLabel, OnCapacityEdit);
+            minEditableLabel = new ToolStripEditableLabel(minStatusLabel, OnMinEdit);
+            maxEditableLabel = new ToolStripEditableLabel(maxStatusLabel, OnMaxEdit);
+            Graph.GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
+            components.Add(capacityEditableLabel);
+            components.Add(minEditableLabel);
+            components.Add(maxEditableLabel);
+        }
+
+        protected StatusStrip StatusStrip
+        {
+            get { return statusStrip; }
+        }
+
+        public BarGraph Graph
+        {
+            get { return graph; }
+        }
+
+        public int NumSeries
+        {
+            get { return graph.NumSeries; }
+            set { graph.EnsureCapacity(value); }
+        }
+
+        public virtual int Capacity
+        {
+            get { return graph.Capacity; }
+            set { graph.Capacity = value; }
+        }
+
+        public bool CanEditCapacity
+        {
+            get { return capacityEditableLabel.Enabled; }
+            set { capacityEditableLabel.Enabled = value; }
+        }
+
+        public double Min
+        {
+            get { return graph.YMin; }
+            set { graph.YMin = value; }
+        }
+
+        public double Max
+        {
+            get { return graph.YMax; }
+            set { graph.YMax = value; }
+        }
+
+        public bool AutoScale
+        {
+            get { return autoScaleButton.Checked; }
+            set { autoScaleButton.Checked = value; }
+        }
+
+        public bool AutoScaleVisible
+        {
+            get { return autoScaleButton.Visible; }
+            set
+            {
+                autoScaleButton.Visible = value;
+                minEditableLabel.Enabled = value;
+                maxEditableLabel.Enabled = value;
+            }
+        }
+
+        public event EventHandler AutoScaleChanged
+        {
+            add { autoScaleButton.CheckedChanged += value; }
+            remove { autoScaleButton.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AxisChanged;
+
+        protected virtual void OnAxisChanged(EventArgs e)
+        {
+            AxisChanged?.Invoke(this, e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            graph.EnsureCapacity(NumSeries);
+            base.OnLoad(e);
+        }
+
+        private bool graph_MouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
+        {
+            var pane = graph.MasterPane.FindChartRect(e.Location);
+            if (pane != null)
+            {
+                pane.ReverseTransform(e.Location, out double x, out double y);
+                cursorStatusLabel.Text = string.Format("Cursor: ({0:F0}, {1:G5})", x, y);
+            }
+            return false;
+        }
+
+        private void graph_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+            }
+        }
+
+        private void GraphPane_AxisChangeEvent(GraphPane pane)
+        {
+            var capacity = graph.Capacity;
+            var scale = pane.YAxis.Scale;
+            autoScaleButton.Checked = pane.YAxis.Scale.MaxAuto;
+            capacityValueLabel.Text = capacity.ToString(CultureInfo.InvariantCulture);
+            minStatusLabel.Text = scale.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabel.Text = scale.Max.ToString("G5", CultureInfo.InvariantCulture);
+            OnAxisChanged(EventArgs.Empty);
+        }
+
+        private void autoScaleButton_CheckedChanged(object sender, EventArgs e)
+        {
+            graph.AutoScaleY = autoScaleButton.Checked;
+            minStatusLabel.Visible = !autoScaleButton.Checked;
+            maxStatusLabel.Visible = !autoScaleButton.Checked;
+        }
+
+        private void OnCapacityEdit(string text)
+        {
+            if (int.TryParse(text, out int capacity))
+            {
+                Capacity = capacity;
+            }
+        }
+
+        private void OnMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                Min = min;
+            }
+        }
+
+        private void OnMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                Max = max;
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraphView.resx
+++ b/src/Bonsai.Gui.Visualizers/BarGraphView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
@@ -25,17 +25,17 @@ namespace Bonsai.Gui.Visualizers
         public int Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the lower limit for the bar range axis when using a fixed scale.
         /// </summary>
         public double Min { get; set; }
 
         /// <summary>
-        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the upper limit for the bar range axis when using a fixed scale.
         /// </summary>
         public double Max { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// Gets or sets a value indicating whether the bar range scale should be recalculated
         /// automatically as the graph updates.
         /// </summary>
         public bool AutoScale { get; set; } = true;

--- a/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
@@ -1,0 +1,171 @@
+﻿using Bonsai.Design;
+using Bonsai.Expressions;
+using System;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display an object as a bar graph.
+    /// </summary>
+    public class BarGraphVisualizer : BufferedVisualizer, IBarGraphVisualizer
+    {
+        BarGraphBuilder.VisualizerController controller;
+        BarGraphView view;
+        bool labelBars;
+        bool reset;
+
+        /// <summary>
+        /// Gets or sets the maximum number of data points displayed at any one moment
+        /// in the bar graph.
+        /// </summary>
+        public int Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double Max { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// automatically as the graph updates.
+        /// </summary>
+        public bool AutoScale { get; set; } = true;
+
+        void IBarGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
+
+        void IBarGraphVisualizer.AddValues(double index, params double[] values) => AddValues(index, null, values);
+
+        void IBarGraphVisualizer.AddValues(double index, string tag, params double[] values) => AddValues(index, tag, values);
+
+        internal void AddValues(double index, string tag, params double[] values)
+        {
+            if (view.Graph.NumSeries != values.Length || reset)
+            {
+                view.Graph.EnsureCapacity(
+                    values.Length,
+                    labelBars ? controller.ValueLabels : null,
+                    reset);
+                reset = false;
+            }
+            view.Graph.AddValues(index, tag, values);
+        }
+
+        static void GetBarGraphAxes(BarBase barBase, GraphControl graph, out Axis indexAxis, out Axis valueAxis)
+        {
+            switch (barBase)
+            {
+                case BarBase.X:
+                case BarBase.X2:
+                    indexAxis = graph.GraphPane.XAxis;
+                    valueAxis = graph.GraphPane.YAxis;
+                    break;
+                case BarBase.Y:
+                case BarBase.Y2:
+                    indexAxis = graph.GraphPane.YAxis;
+                    valueAxis = graph.GraphPane.XAxis;
+                    break;
+                default: throw new ArgumentOutOfRangeException(nameof(barBase));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var barChartBuilder = (BarGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = barChartBuilder.Controller;
+
+            view = new BarGraphView();
+            view.Dock = DockStyle.Fill;
+            view.Graph.BaseAxis = controller.BaseAxis;
+            view.Graph.BarType = controller.BarType;
+            GetBarGraphAxes(controller.BaseAxis, view.Graph, out Axis indexAxis, out Axis valueAxis);
+            GraphHelper.FormatOrdinalAxis(indexAxis, typeof(string));
+            GraphHelper.SetAxisLabel(indexAxis, controller.IndexLabel);
+            indexAxis.Scale.IsReverse = controller.BaseAxis == BarBase.Y;
+            indexAxis.MajorTic.IsInside = false;
+
+            if (controller.Min.HasValue || controller.Max.HasValue)
+            {
+                view.AutoScale = false;
+                view.AutoScaleVisible = false;
+                view.Min = controller.Min.GetValueOrDefault();
+                view.Max = controller.Max.GetValueOrDefault();
+            }
+            else
+            {
+                view.AutoScale = AutoScale;
+                if (!AutoScale)
+                {
+                    view.Min = Min;
+                    view.Max = Max;
+                }
+            }
+
+            if (controller.Capacity.HasValue)
+            {
+                view.Capacity = controller.Capacity.Value;
+                view.CanEditCapacity = false;
+            }
+            else
+            {
+                view.Capacity = Capacity;
+                view.CanEditCapacity = true;
+            }
+
+            var hasLabels = controller.ValueLabels != null;
+            var labelAxis = hasLabels && controller.ValueLabels.Length == 1;
+            if (labelAxis) GraphHelper.SetAxisLabel(valueAxis, controller.ValueLabels[0]);
+            labelBars = hasLabels && !labelAxis;
+            if (hasLabels)
+            {
+                view.Graph.EnsureCapacity(
+                    controller.ValueLabels.Length,
+                    labelBars ? controller.ValueLabels : null);
+            }
+
+            view.HandleDestroyed += delegate
+            {
+                Min = view.Min;
+                Max = view.Max;
+                AutoScale = view.AutoScale;
+                Capacity = view.Capacity;
+            };
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(view);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            controller.AddValues(value, this);
+            view.Graph.Invalidate();
+        }
+
+        /// <inheritdoc/>
+        public override void SequenceCompleted()
+        {
+            reset = true;
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            view.Dispose();
+            view = null;
+            controller = null;
+            reset = false;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
@@ -1,6 +1,8 @@
 ﻿using Bonsai.Design;
 using Bonsai.Expressions;
 using System;
+using System.Collections.Generic;
+using System.Reactive;
 using System.Windows.Forms;
 using ZedGraph;
 
@@ -150,7 +152,16 @@ namespace Bonsai.Gui.Visualizers
         public override void Show(object value)
         {
             controller.AddValues(value, this);
-            view.Graph.Invalidate();
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
+            {
+                view.Graph.Invalidate();
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
+++ b/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+  <ItemGroup>
+    <Compile Update="BarGraph.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="BarGraphView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="GraphControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="GraphPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="GraphPanelView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="LineGraph.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="LineGraphView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="RollingGraph.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="RollingGraphView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
+++ b/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
@@ -8,13 +8,22 @@
     <Compile Update="BarGraphView.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="BoundedGraphPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="GraphControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="GraphPanel.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="GraphPanel2D.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="GraphPanelView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="GraphPanelView2D.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="LineGraph.cs">

--- a/src/Bonsai.Gui.Visualizers/BoundedGraphPanel.cs
+++ b/src/Bonsai.Gui.Visualizers/BoundedGraphPanel.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    internal abstract class BoundedGraphPanel : GraphControl
+    {
+        double span;
+        int capacity;
+        int? setCapacity;
+
+        public BoundedGraphPanel()
+        {
+            IsShowContextMenu = false;
+            ZoomEvent += GraphPanel_ZoomEvent;
+            MasterPane = new ViewPane(MasterPane);
+        }
+
+        public double Span
+        {
+            get { return span; }
+            set
+            {
+                span = value;
+                Invalidate();
+            }
+        }
+
+        public int Capacity
+        {
+            get { return capacity; }
+            set
+            {
+                capacity = value;
+                setCapacity = capacity;
+                Invalidate();
+            }
+        }
+
+        protected override void OnInvalidated(InvalidateEventArgs e)
+        {
+            double? maxValue = null;
+            var curveList = GraphPane.CurveList;
+            for (int i = 0; i < curveList.Count; i++)
+            {
+                if (curveList[i].Points is BoundedPointPairList boundedList)
+                {
+                    if (span <= 0)
+                    {
+                        boundedList.SetBounds(double.MinValue, double.MaxValue);
+                    }
+                    else if (boundedList.Count > 0)
+                    {
+                        maxValue = Math.Max(
+                            maxValue.GetValueOrDefault(double.MinValue),
+                            boundedList[boundedList.Count - 1].Z);
+                    }
+                }
+            }
+
+            if (maxValue != null)
+            {
+                var lowerBound = maxValue.GetValueOrDefault() - span;
+                for (int i = 0; i < curveList.Count; i++)
+                {
+                    if (curveList[i].Points is BoundedPointPairList boundedList)
+                    {
+                        boundedList.SetBounds(lowerBound, double.MaxValue);
+                    }
+                }
+            }
+
+            if (setCapacity != null)
+            {
+                for (int i = 0; i < curveList.Count; i++)
+                {
+                    if (curveList[i].Points is BoundedPointPairList boundedList)
+                    {
+                        boundedList.SetCapacity(capacity);
+                    }
+                }
+
+                setCapacity = null;
+            }
+
+            base.OnInvalidated(e);
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.P)
+            {
+                DoPrint();
+            }
+
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.S)
+            {
+                SaveAs();
+            }
+
+            if (e.KeyCode == Keys.Back)
+            {
+                ZoomOut(GraphPane);
+            }
+
+            base.OnKeyDown(e);
+        }
+
+        private void GraphPanel_ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
+        {
+            MasterPane.AxisChange();
+        }
+
+        internal class ViewPane : MasterPane
+        {
+            public ViewPane(MasterPane masterPane)
+                : base(masterPane.Title.Text, masterPane.Rect)
+            {
+                Margin.All = 0;
+                Title.IsVisible = false;
+                Add(masterPane.PaneList[0]);
+            }
+
+            public float StatusGap { get; set; }
+
+            public override void ReSize(Graphics g, RectangleF rect)
+            {
+                rect.Height -= StatusGap;
+                base.ReSize(g, rect);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BoundedPointPairList.cs
+++ b/src/Bonsai.Gui.Visualizers/BoundedPointPairList.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    internal class BoundedPointPairList : IPointListEdit
+    {
+        int maxCapacity = int.MaxValue;
+        double minValue = double.MinValue;
+        double maxValue = double.MaxValue;
+        readonly PointPairDeque points = new();
+
+        public BoundedPointPairList()
+            : this(0)
+        {
+        }
+
+        public BoundedPointPairList(int capacity)
+        {
+            SetCapacity(capacity);
+        }
+
+        public BoundedPointPairList(IPointList points, int capacity)
+            : this(capacity)
+        {
+            if (points != null)
+            {
+                for (int i = 0; i < points.Count; i++)
+                {
+                    Add(points[i]);
+                }
+            }
+        }
+
+        private void EnsureCapacity()
+        {
+            while (points.Count > maxCapacity)
+            {
+                points.TryDequeue(out _);
+            }
+        }
+
+        public void SetBounds(double min, double max)
+        {
+            if (max < min) ThrowHelper.ThrowArgumentOutOfRange(nameof(max));
+
+            minValue = min;
+            maxValue = max;
+            while (points.Count > 0 && points[0].Z < min)
+            {
+                points.TryDequeue(out _);
+            }
+
+            while (points.Count > 0 && points[points.Count - 1].Z > max)
+            {
+                points.TryDequeueLast(out _);
+            }
+        }
+
+        public void SetCapacity(int capacity)
+        {
+            if (capacity < 0) ThrowHelper.ThrowArgumentOutOfRange(nameof(capacity));
+            maxCapacity = capacity > 0 ? capacity : int.MaxValue;
+            EnsureCapacity();
+        }
+
+        public PointPair this[int index]
+        {
+            get => points[index];
+            set => points[index] = value;
+        }
+
+        PointPair IPointList.this[int index] => this[index];
+
+        public int Count => points.Count;
+
+        public void Add(PointPair point)
+        {
+            if (point == null)
+            {
+                ThrowHelper.ThrowArgumentNull(nameof(point));
+            }
+
+            Add(point.X, point.Y, point.Z, point.Tag);
+        }
+
+        public void Add(double x, double y)
+        {
+            Add(x, y, 0, null);
+        }
+
+        public void Add(double x, double y, string label)
+        {
+            Add(x, y, 0, label);
+        }
+
+        public void Add(double x, double y, double z, object tag)
+        {
+            if (x >= minValue && x <= maxValue)
+            {
+                points.Enqueue(x, y, z, tag);
+            }
+
+            EnsureCapacity();
+        }
+
+        public void Clear()
+        {
+            points.Clear();
+        }
+
+        public object Clone()
+        {
+            return new BoundedPointPairList(this, maxCapacity);
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/BoundedPointPairList.cs
+++ b/src/Bonsai.Gui.Visualizers/BoundedPointPairList.cs
@@ -96,7 +96,7 @@ namespace Bonsai.Gui.Visualizers
 
         public void Add(double x, double y, double z, object tag)
         {
-            if (x >= minValue && x <= maxValue)
+            if (z >= minValue && z <= maxValue)
             {
                 points.Enqueue(x, y, z, tag);
             }

--- a/src/Bonsai.Gui.Visualizers/CurveConfiguration.cs
+++ b/src/Bonsai.Gui.Visualizers/CurveConfiguration.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel;
+using System.Drawing;
+using System.Xml.Serialization;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents common configuration properties for individual curves in a graph.
+    /// </summary>
+    public class CurveConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the label that will appear in the legend.
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the curve.
+        /// </summary>
+        [XmlIgnore]
+        public Color Color { get; set; }
+
+        /// <summary>
+        /// Gets or sets an HTML representation of the curve color value for serialization.
+        /// </summary>
+        [Browsable(false)]
+        [XmlElement(nameof(Color))]
+        public string ColorHtml
+        {
+            get { return ColorTranslator.ToHtml(Color); }
+            set { Color = ColorTranslator.FromHtml(value); }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphHelper.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphHelper.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Xml.Serialization;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    static class GraphHelper
+    {
+        static readonly ConstructorInfo NewPointPair = typeof(PointPair).GetConstructor(new[] { typeof(double), typeof(double) });
+
+        internal static void SetAxisLabel(Axis axis, string label)
+        {
+            axis.Title.Text = label;
+            axis.Title.IsVisible = !string.IsNullOrEmpty(label);
+        }
+
+        internal static void FormatLinearDateAxis(Axis axis)
+        {
+            axis.Type = AxisType.Date;
+            axis.Scale.Format = "HH:mm:ss";
+            axis.Scale.MajorUnit = DateUnit.Second;
+            axis.Scale.MinorUnit = DateUnit.Millisecond;
+            axis.MinorTic.IsAllTics = false;
+        }
+
+        internal static void FormatDateAxis(Axis axis)
+        {
+            axis.Type = AxisType.DateAsOrdinal;
+            axis.Scale.Format = "HH:mm:ss";
+            axis.Scale.MajorUnit = DateUnit.Second;
+            axis.Scale.MinorUnit = DateUnit.Millisecond;
+            axis.MinorTic.IsAllTics = false;
+        }
+
+        internal static void FormatOrdinalAxis(Axis axis, Type type)
+        {
+            if (type == typeof(XDate))
+            {
+                FormatDateAxis(axis);
+            }
+            else if (type == typeof(string))
+            {
+                axis.Type = AxisType.Text;
+                axis.MinorTic.IsAllTics = false;
+                axis.ScaleFormatEvent += (graph, axis, value, index) =>
+                {
+                    if (graph.CurveList.Count == 0) return null;
+                    var series = graph.CurveList[0];
+                    index *= (int)axis.Scale.MajorStep;
+                    return index < series.NPts ? series[index].Tag as string : null;
+                };
+            }
+            else
+            {
+                axis.Type = AxisType.LinearAsOrdinal;
+                if (type.IsPrimitive && IsIntegralType(type))
+                {
+                    axis.Scale.Format = "F0";
+                    axis.MinorTic.IsAllTics = false;
+                }
+                else axis.Scale.Format = "F2";
+            }
+        }
+
+        static bool IsIntegralType(Type type)
+        {
+            var typeCode = Type.GetTypeCode(type);
+            switch (typeCode)
+            {
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                case TypeCode.Char:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        internal static Expression SelectIndexMember(Expression expression, string indexSelector, out string indexLabel)
+        {
+            return SelectIndexMember(time: null, expression, indexSelector, out indexLabel);
+        }
+
+        internal static Expression SelectIndexMember(Expression time, Expression expression, string indexSelector, out string indexLabel)
+        {
+            Expression selectedIndex;
+            if (!string.IsNullOrEmpty(indexSelector))
+            {
+                selectedIndex = ExpressionHelper.SelectMembers(expression, indexSelector).First();
+                indexLabel = indexSelector;
+            }
+            else
+            {
+                selectedIndex = time ?? Expression.Property(null, typeof(DateTime), nameof(DateTime.Now));
+                indexLabel = "Time";
+            }
+
+            if (selectedIndex.Type == typeof(DateTimeOffset)) selectedIndex = Expression.Property(selectedIndex, nameof(DateTimeOffset.DateTime));
+            if (selectedIndex.Type == typeof(DateTime))
+            {
+                selectedIndex = Expression.Convert(selectedIndex, typeof(XDate));
+            }
+
+            return selectedIndex;
+        }
+
+        internal static Expression SelectDataValues(Expression expression, string valueSelector, out string[] valueLabels)
+        {
+            Expression selectedValues;
+            var memberNames = ExpressionHelper.SelectMemberNames(valueSelector).ToArray();
+            if (memberNames.Length == 0) memberNames = new[] { ExpressionHelper.ImplicitParameterName };
+            var selectedMembers = memberNames.Select(name => ExpressionHelper.MemberAccess(expression, name))
+                .SelectMany(UnwrapMemberAccess)
+                .Select(x => x.Type.IsArray ? x : Expression.Convert(x, typeof(double))).ToArray();
+            if (selectedMembers.Length == 1 && selectedMembers[0].Type.IsArray)
+            {
+                valueLabels = null;
+                selectedValues = ConvertArray(selectedMembers[0], typeof(double));
+            }
+            else
+            {
+                valueLabels = memberNames;
+                selectedValues = Expression.NewArrayInit(typeof(double), selectedMembers);
+            }
+
+            return selectedValues;
+        }
+
+        internal static Expression SelectDataPoints(Expression expression, string valueSelector, out string[] valueLabels)
+        {
+            return SelectDataPoints(expression, valueSelector, out valueLabels, out _);
+        }
+
+        internal static Expression SelectDataPoints(Expression expression, string valueSelector, out string[] valueLabels, out bool labelAxes)
+        {
+            labelAxes = false;
+            var memberNames = ExpressionHelper.SelectMemberNames(valueSelector).ToArray();
+            if (memberNames.Length == 0) memberNames = new[] { ExpressionHelper.ImplicitParameterName };
+            if (memberNames.Length == 1)
+            {
+                var memberName = memberNames[0];
+                valueLabels = memberName != ExpressionHelper.ImplicitParameterName ? new[] { memberName } : null;
+                var member = ExpressionHelper.MemberAccess(expression, memberNames[0]);
+                if (member.Type.IsArray)
+                {
+                    if (member.Type != typeof(PointPair[]))
+                    {
+                        var arrayElement = Expression.Parameter(member.Type.GetElementType());
+                        member = ConvertArray(member, GetPointPair(arrayElement), arrayElement);
+                    }
+
+                    return member;
+                }
+                else return Expression.NewArrayInit(typeof(PointPair), GetPointPair(member));
+            }
+
+            valueLabels = memberNames;
+            var members = Array.ConvertAll(memberNames, name => ExpressionHelper.MemberAccess(expression, name));
+            if (members.Length == 2 && members[0].Type.IsPrimitive && members[1].Type.IsPrimitive)
+            {
+                labelAxes = true;
+                var x = Expression.Convert(members[0], typeof(double));
+                var y = Expression.Convert(members[1], typeof(double));
+                return Expression.NewArrayInit(typeof(PointPair), Expression.New(NewPointPair, x, y));
+            }
+
+            for (int i = 0; i < members.Length; i++)
+            {
+                members[i] = GetPointPair(members[i]);
+            }
+            return Expression.NewArrayInit(typeof(PointPair), members);
+        }
+
+        static Expression ConvertArray(Expression array, Type targetType)
+        {
+            var elementType = array.Type.GetElementType();
+            if (elementType != targetType)
+            {
+                var arrayElement = Expression.Parameter(array.Type.GetElementType());
+                var converterBody = Expression.Convert(arrayElement, targetType);
+                array = ConvertArray(array, converterBody, arrayElement);
+            }
+
+            return array;
+        }
+
+        static Expression ConvertArray(Expression array, Expression body, ParameterExpression parameter)
+        {
+            var typeArguments = new[] { parameter.Type, body.Type };
+            var converterType = typeof(Converter<,>).MakeGenericType(typeArguments);
+            return Expression.Call(
+                typeof(Array),
+                nameof(Array.ConvertAll),
+                typeArguments, array,
+                Expression.Lambda(converterType, body, parameter));
+        }
+
+        static Expression GetDoubleMember(Expression expression, string memberName)
+        {
+            var member = (Expression)Expression.PropertyOrField(expression, memberName);
+            return member.Type != typeof(double) ? Expression.Convert(member, typeof(double)) : member;
+        }
+
+        static Expression GetPointPair(Expression expression)
+        {
+            if (expression.Type == typeof(PointPair)) return expression;
+            if (expression.Type == typeof(Tuple<,>))
+            {
+                return Expression.New(NewPointPair,
+                    GetDoubleMember(expression, "Item1"),
+                    GetDoubleMember(expression, "Item2"));
+            }
+
+            return Expression.New(NewPointPair,
+                GetDoubleMember(expression, nameof(PointPair.X)),
+                GetDoubleMember(expression, nameof(PointPair.Y)));
+        }
+
+        static IEnumerable<MemberInfo> GetDataMembers(Type type)
+        {
+            var members = Enumerable.Concat<MemberInfo>(
+                type.GetFields(BindingFlags.Instance | BindingFlags.Public),
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public));
+            if (type.IsInterface)
+            {
+                members = members.Concat(type
+                    .GetInterfaces()
+                    .SelectMany(i => i.GetProperties(BindingFlags.Instance | BindingFlags.Public)));
+            }
+            return members.Where(member => !member.IsDefined(typeof(XmlIgnoreAttribute), true))
+                          .OrderBy(member => member.MetadataToken)
+                          .Except(type.GetDefaultMembers());
+        }
+
+        static IEnumerable<Expression> UnwrapMemberAccess(Expression expression)
+        {
+            if (expression.Type == typeof(string) || IsNullable(expression.Type)) yield return expression;
+            else if (expression.Type.IsPrimitive || expression.Type.IsEnum || expression.Type.IsArray ||
+                     expression.Type == typeof(string) || expression.Type == typeof(TimeSpan) ||
+                     expression.Type == typeof(DateTime) || expression.Type == typeof(DateTimeOffset))
+            {
+                yield return expression;
+            }
+            else
+            {
+                var successors = from member in GetDataMembers(expression.Type)
+                                 let memberAccess = (Expression)Expression.MakeMemberAccess(expression, member)
+                                 select memberAccess;
+                foreach (var successor in successors)
+                {
+                    yield return successor;
+                }
+            }
+        }
+
+        static bool IsNullable(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanel.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanel.cs
@@ -1,194 +1,61 @@
-﻿using System;
-using System.Windows.Forms;
-using ZedGraph;
+﻿using ZedGraph;
 
 namespace Bonsai.Gui.Visualizers
 {
-    internal class GraphPanel : GraphControl
+    internal class GraphPanel : BoundedGraphPanel
     {
-        double span;
-        int capacity;
-        bool autoScaleX;
-        bool autoScaleY;
-        int? setCapacity;
+        bool autoScale;
 
         public GraphPanel()
         {
-            autoScaleX = true;
-            autoScaleY = true;
-            IsShowContextMenu = false;
-            ZoomEvent += GraphPanel_ZoomEvent;
+            autoScale = true;
         }
 
-        public double Span
+        public Axis ScaleAxis => GraphPane.BarSettings.Base switch
         {
-            get { return span; }
-            set
-            {
-                span = value;
-                Invalidate();
-            }
-        }
+            BarBase.Y => GraphPane.XAxis,
+            BarBase.Y2 => GraphPane.X2Axis,
+            BarBase.X2 => GraphPane.Y2Axis,
+            _ => GraphPane.YAxis
+        };
 
-        public int Capacity
+        public double Min
         {
-            get { return capacity; }
+            get { return ScaleAxis.Scale.Min; }
             set
             {
-                capacity = value;
-                setCapacity = capacity;
-                Invalidate();
-            }
-        }
-
-        public double XMin
-        {
-            get { return GraphPane.XAxis.Scale.Min; }
-            set
-            {
-                GraphPane.XAxis.Scale.Min = value;
+                ScaleAxis.Scale.Min = value;
                 GraphPane.AxisChange();
                 Invalidate();
             }
         }
 
-        public double XMax
+        public double Max
         {
-            get { return GraphPane.XAxis.Scale.Max; }
+            get { return ScaleAxis.Scale.Max; }
             set
             {
-                GraphPane.XAxis.Scale.Max = value;
+                ScaleAxis.Scale.Max = value;
                 GraphPane.AxisChange();
                 Invalidate();
             }
         }
 
-        public double YMin
+        public bool AutoScale
         {
-            get { return GraphPane.YAxis.Scale.Min; }
+            get { return autoScale; }
             set
             {
-                GraphPane.YAxis.Scale.Min = value;
-                GraphPane.AxisChange();
-                Invalidate();
-            }
-        }
-
-        public double YMax
-        {
-            get { return GraphPane.YAxis.Scale.Max; }
-            set
-            {
-                GraphPane.YAxis.Scale.Max = value;
-                GraphPane.AxisChange();
-                Invalidate();
-            }
-        }
-
-        public bool AutoScaleX
-        {
-            get { return autoScaleX; }
-            set
-            {
-                var changed = autoScaleX != value;
-                autoScaleX = value;
+                var changed = autoScale != value;
+                autoScale = value;
                 if (changed)
                 {
-                    GraphPane.XAxis.Scale.MaxAuto = autoScaleX;
-                    GraphPane.XAxis.Scale.MinAuto = autoScaleX;
-                    if (autoScaleX) Invalidate();
+                    var baseAxis = ScaleAxis;
+                    baseAxis.Scale.MaxAuto = autoScale;
+                    baseAxis.Scale.MinAuto = autoScale;
+                    if (autoScale) Invalidate();
                 }
             }
-        }
-
-        public bool AutoScaleY
-        {
-            get { return autoScaleY; }
-            set
-            {
-                var changed = autoScaleY != value;
-                autoScaleY = value;
-                if (changed)
-                {
-                    GraphPane.YAxis.Scale.MaxAuto = autoScaleY;
-                    GraphPane.YAxis.Scale.MinAuto = autoScaleY;
-                    if (autoScaleY) Invalidate();
-                }
-            }
-        }
-
-        protected override void OnInvalidated(InvalidateEventArgs e)
-        {
-            double? maxValue = null;
-            var curveList = GraphPane.CurveList;
-            for (int i = 0; i < curveList.Count; i++)
-            {
-                if (curveList[i].Points is BoundedPointPairList boundedList)
-                {
-                    if (span <= 0)
-                    {
-                        boundedList.SetBounds(double.MinValue, double.MaxValue);
-                    }
-                    else if (boundedList.Count > 0)
-                    {
-                        maxValue = Math.Max(
-                            maxValue.GetValueOrDefault(double.MinValue),
-                            boundedList[boundedList.Count - 1].Z);
-                    }
-                }
-            }
-
-            if (maxValue != null)
-            {
-                var lowerBound = maxValue.GetValueOrDefault() - span;
-                for (int i = 0; i < curveList.Count; i++)
-                {
-                    if (curveList[i].Points is BoundedPointPairList boundedList)
-                    {
-                        boundedList.SetBounds(lowerBound, double.MaxValue);
-                    }
-                }
-            }
-
-            if (setCapacity != null)
-            {
-                for (int i = 0; i < curveList.Count; i++)
-                {
-                    if (curveList[i].Points is BoundedPointPairList boundedList)
-                    {
-                        boundedList.SetCapacity(capacity);
-                    }
-                }
-
-                setCapacity = null;
-            }
-
-            base.OnInvalidated(e);
-        }
-
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.P)
-            {
-                DoPrint();
-            }
-
-            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.S)
-            {
-                SaveAs();
-            }
-
-            if (e.KeyCode == Keys.Back)
-            {
-                ZoomOut(GraphPane);
-            }
-
-            base.OnKeyDown(e);
-        }
-
-        private void GraphPanel_ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
-        {
-            MasterPane.AxisChange();
         }
     }
 }

--- a/src/Bonsai.Gui.Visualizers/GraphPanel.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanel.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    internal class GraphPanel : GraphControl
+    {
+        double span;
+        int capacity;
+        bool autoScaleX;
+        bool autoScaleY;
+        int? setCapacity;
+
+        public GraphPanel()
+        {
+            autoScaleX = true;
+            autoScaleY = true;
+            IsShowContextMenu = false;
+            ZoomEvent += GraphPanel_ZoomEvent;
+        }
+
+        public double Span
+        {
+            get { return span; }
+            set
+            {
+                span = value;
+                Invalidate();
+            }
+        }
+
+        public int Capacity
+        {
+            get { return capacity; }
+            set
+            {
+                capacity = value;
+                setCapacity = capacity;
+                Invalidate();
+            }
+        }
+
+        public double XMin
+        {
+            get { return GraphPane.XAxis.Scale.Min; }
+            set
+            {
+                GraphPane.XAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double XMax
+        {
+            get { return GraphPane.XAxis.Scale.Max; }
+            set
+            {
+                GraphPane.XAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMin
+        {
+            get { return GraphPane.YAxis.Scale.Min; }
+            set
+            {
+                GraphPane.YAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMax
+        {
+            get { return GraphPane.YAxis.Scale.Max; }
+            set
+            {
+                GraphPane.YAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public bool AutoScaleX
+        {
+            get { return autoScaleX; }
+            set
+            {
+                var changed = autoScaleX != value;
+                autoScaleX = value;
+                if (changed)
+                {
+                    GraphPane.XAxis.Scale.MaxAuto = autoScaleX;
+                    GraphPane.XAxis.Scale.MinAuto = autoScaleX;
+                    if (autoScaleX) Invalidate();
+                }
+            }
+        }
+
+        public bool AutoScaleY
+        {
+            get { return autoScaleY; }
+            set
+            {
+                var changed = autoScaleY != value;
+                autoScaleY = value;
+                if (changed)
+                {
+                    GraphPane.YAxis.Scale.MaxAuto = autoScaleY;
+                    GraphPane.YAxis.Scale.MinAuto = autoScaleY;
+                    if (autoScaleY) Invalidate();
+                }
+            }
+        }
+
+        protected override void OnInvalidated(InvalidateEventArgs e)
+        {
+            double? maxValue = null;
+            var curveList = GraphPane.CurveList;
+            for (int i = 0; i < curveList.Count; i++)
+            {
+                if (curveList[i].Points is BoundedPointPairList boundedList)
+                {
+                    if (span <= 0)
+                    {
+                        boundedList.SetBounds(double.MinValue, double.MaxValue);
+                    }
+                    else if (boundedList.Count > 0)
+                    {
+                        maxValue = Math.Max(
+                            maxValue.GetValueOrDefault(double.MinValue),
+                            boundedList[boundedList.Count - 1].Z);
+                    }
+                }
+            }
+
+            if (maxValue != null)
+            {
+                var lowerBound = maxValue.GetValueOrDefault() - span;
+                for (int i = 0; i < curveList.Count; i++)
+                {
+                    if (curveList[i].Points is BoundedPointPairList boundedList)
+                    {
+                        boundedList.SetBounds(lowerBound, double.MaxValue);
+                    }
+                }
+            }
+
+            if (setCapacity != null)
+            {
+                for (int i = 0; i < curveList.Count; i++)
+                {
+                    if (curveList[i].Points is BoundedPointPairList boundedList)
+                    {
+                        boundedList.SetCapacity(capacity);
+                    }
+                }
+
+                setCapacity = null;
+            }
+
+            base.OnInvalidated(e);
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.P)
+            {
+                DoPrint();
+            }
+
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.S)
+            {
+                SaveAs();
+            }
+
+            if (e.KeyCode == Keys.Back)
+            {
+                ZoomOut(GraphPane);
+            }
+
+            base.OnKeyDown(e);
+        }
+
+        private void GraphPanel_ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
+        {
+            MasterPane.AxisChange();
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reactive;
+using Bonsai.Expressions;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that specifies a mashup graph panel that can be used
+    /// to combine multiple plots sharing the same axes.
+    /// </summary>
+    [TypeVisualizer(typeof(GraphPanelVisualizer))]
+    public class GraphPanelBuilder : ZeroArgumentExpressionBuilder, INamedElement
+    {
+        /// <summary>
+        /// Gets or sets the name of the visualizer window.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The name of the visualizer window.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying the axis on which the bars in the graph will be displayed.
+        /// </summary>
+        [TypeConverter(typeof(BaseAxisConverter))]
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies the axis on which the bars in the graph will be displayed.")]
+        public BarBase BaseAxis { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying how the different bars in the graph will be visually arranged.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies how the different bars in the graph will be visually arranged.")]
+        public BarType BarType { get; set; }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// graph panel visualizer.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
@@ -13,6 +13,7 @@ namespace Bonsai.Gui.Visualizers
     /// to combine multiple plots sharing the same axes.
     /// </summary>
     [TypeVisualizer(typeof(GraphPanelVisualizer))]
+    [Description("Specifies a mashup graph panel that can be used to combine multiple plots sharing the same axes.")]
     public class GraphPanelBuilder : ZeroArgumentExpressionBuilder, INamedElement
     {
         /// <summary>
@@ -38,12 +39,65 @@ namespace Bonsai.Gui.Visualizers
         public BarType BarType { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional maximum span of data displayed at any one moment in the graph.
+        /// If no span is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional maximum span of data displayed at any one moment in the graph. " +
+                     "If no span is specified, all data points will be displayed.")]
+        public double? Span { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.")]
+        public int? Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the axis range.")]
+        public double? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the axis range.")]
+        public double? Max { get; set; }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal BarBase BaseAxis;
+            internal BarType BarType;
+            internal double? Span;
+            internal int? Capacity;
+            internal double? Min;
+            internal double? Max;
+        }
+
+        /// <summary>
         /// Builds the expression tree for configuring and calling the
         /// graph panel visualizer.
         /// </summary>
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {
+            Controller = new VisualizerController
+            {
+                BaseAxis = BaseAxis,
+                BarType = BarType,
+                Span = Span,
+                Capacity = Capacity,
+                Min = Min,
+                Max = Max
+            };
             return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
         }
     }

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
@@ -39,6 +39,20 @@ namespace Bonsai.Gui.Visualizers
         public BarType BarType { get; set; }
 
         /// <summary>
+        /// Gets or sets a value specifying whether the scale values are reversed on the X-axis.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies whether the scale values are reversed on the X-axis.")]
+        public bool ReverseX { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the scale values are reversed on the Y-axis.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies whether the scale values are reversed on the Y-axis.")]
+        public bool ReverseY { get; set; }
+
+        /// <summary>
         /// Gets or sets the optional maximum span of data displayed at any one moment in the graph.
         /// If no span is specified, all data points will be displayed.
         /// </summary>
@@ -80,6 +94,8 @@ namespace Bonsai.Gui.Visualizers
             internal int? Capacity;
             internal double? Min;
             internal double? Max;
+            internal bool ReverseX;
+            internal bool ReverseY;
         }
 
         /// <summary>
@@ -96,7 +112,9 @@ namespace Bonsai.Gui.Visualizers
                 Span = Span,
                 Capacity = Capacity,
                 Min = Min,
-                Max = Max
+                Max = Max,
+                ReverseX = ReverseX,
+                ReverseY = ReverseY
             };
             return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
         }

--- a/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
@@ -1,0 +1,197 @@
+﻿namespace Bonsai.Gui.Visualizers
+{
+    partial class GraphPanelView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.spanStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.spanValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButtonX = new System.Windows.Forms.ToolStripButton();
+            this.autoScaleButtonY = new System.Windows.Forms.ToolStripButton();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.spanStatusLabel,
+            this.spanValueLabel,
+            this.capacityStatusLabel,
+            this.capacityValueLabel,
+            this.scaleStatusLabelX,
+            this.minStatusLabelX,
+            this.maxStatusLabelX,
+            this.autoScaleButtonX,
+            this.scaleStatusLabelY,
+            this.minStatusLabelY,
+            this.maxStatusLabelY,
+            this.autoScaleButtonY});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip1";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // spanStatusLabel
+            // 
+            this.spanStatusLabel.Name = "spanStatusLabel";
+            this.spanStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.spanStatusLabel.Text = "Span:";
+            // 
+            // spanValueLabel
+            // 
+            this.spanValueLabel.Name = "spanValueLabel";
+            this.spanValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.spanValueLabel.Text = "value";
+            // 
+            // capacityStatusLabel
+            // 
+            this.capacityStatusLabel.Name = "capacityStatusLabel";
+            this.capacityStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.capacityStatusLabel.Text = "Capacity:";
+            // 
+            // capacityValueLabel
+            // 
+            this.capacityValueLabel.Name = "capacityValueLabel";
+            this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.capacityValueLabel.Text = "count";
+            // 
+            // scaleStatusLabelX
+            // 
+            this.scaleStatusLabelX.Name = "statusLabelX";
+            this.scaleStatusLabelX.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelX.Text = "X:";
+            // 
+            // minStatusLabelX
+            // 
+            this.minStatusLabelX.Name = "minStatusLabelX";
+            this.minStatusLabelX.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelX.Text = "min";
+            this.minStatusLabelX.Visible = false;
+            // 
+            // maxStatusLabelX
+            // 
+            this.maxStatusLabelX.Name = "maxStatusLabelX";
+            this.maxStatusLabelX.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelX.Text = "Max";
+            this.maxStatusLabelX.Visible = false;
+            // 
+            // autoScaleButtonX
+            // 
+            this.autoScaleButtonX.Checked = true;
+            this.autoScaleButtonX.CheckOnClick = true;
+            this.autoScaleButtonX.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonX.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonX.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonX.Name = "autoScaleButtonX";
+            this.autoScaleButtonX.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonX.Text = "auto";
+            this.autoScaleButtonX.CheckedChanged += new System.EventHandler(this.autoScaleButtonX_CheckedChanged);
+            // 
+            // scaleStatusLabelY
+            // 
+            this.scaleStatusLabelY.Name = "statusLabelY";
+            this.scaleStatusLabelY.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelY.Text = "Y:";
+            // 
+            // minStatusLabelY
+            // 
+            this.minStatusLabelY.Name = "minStatusLabelY";
+            this.minStatusLabelY.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelY.Text = "min";
+            this.minStatusLabelY.Visible = false;
+            // 
+            // maxStatusLabelY
+            // 
+            this.maxStatusLabelY.Name = "maxStatusLabelY";
+            this.maxStatusLabelY.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelY.Text = "Max";
+            this.maxStatusLabelY.Visible = false;
+            // 
+            // autoScaleButtonY
+            // 
+            this.autoScaleButtonY.Checked = true;
+            this.autoScaleButtonY.CheckOnClick = true;
+            this.autoScaleButtonY.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonY.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonY.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonY.Name = "autoScaleButtonY";
+            this.autoScaleButtonY.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonY.Text = "auto";
+            this.autoScaleButtonY.CheckedChanged += new System.EventHandler(this.autoScaleButtonY_CheckedChanged);
+            // 
+            // GraphPanelView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.statusStrip);
+            this.Name = "GraphPanelView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonX;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonY;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
+        private System.Windows.Forms.ToolStripStatusLabel spanStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel spanValueLabel;
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
@@ -35,14 +35,10 @@
             this.spanValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.scaleStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
-            this.minStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
-            this.maxStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
-            this.scaleStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
-            this.minStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
-            this.maxStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
-            this.autoScaleButtonX = new System.Windows.Forms.ToolStripButton();
-            this.autoScaleButtonY = new System.Windows.Forms.ToolStripButton();
+            this.scaleStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButton = new System.Windows.Forms.ToolStripButton();
             this.statusStrip.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -54,14 +50,10 @@
             this.spanValueLabel,
             this.capacityStatusLabel,
             this.capacityValueLabel,
-            this.scaleStatusLabelX,
-            this.minStatusLabelX,
-            this.maxStatusLabelX,
-            this.autoScaleButtonX,
-            this.scaleStatusLabelY,
-            this.minStatusLabelY,
-            this.maxStatusLabelY,
-            this.autoScaleButtonY});
+            this.scaleStatusLabel,
+            this.minStatusLabel,
+            this.maxStatusLabel,
+            this.autoScaleButton});
             this.statusStrip.Location = new System.Drawing.Point(0, 218);
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.Size = new System.Drawing.Size(400, 22);
@@ -99,69 +91,37 @@
             this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
             this.capacityValueLabel.Text = "count";
             // 
-            // scaleStatusLabelX
+            // scaleStatusLabel
             // 
-            this.scaleStatusLabelX.Name = "statusLabelX";
-            this.scaleStatusLabelX.Size = new System.Drawing.Size(47, 17);
-            this.scaleStatusLabelX.Text = "X:";
+            this.scaleStatusLabel.Name = "scaleStatusLabel";
+            this.scaleStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabel.Text = "Scale:";
             // 
-            // minStatusLabelX
+            // minStatusLabel
             // 
-            this.minStatusLabelX.Name = "minStatusLabelX";
-            this.minStatusLabelX.Size = new System.Drawing.Size(13, 17);
-            this.minStatusLabelX.Text = "min";
-            this.minStatusLabelX.Visible = false;
+            this.minStatusLabel.Name = "minStatusLabel";
+            this.minStatusLabel.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabel.Text = "min";
+            this.minStatusLabel.Visible = false;
             // 
-            // maxStatusLabelX
+            // maxStatusLabel
             // 
-            this.maxStatusLabelX.Name = "maxStatusLabelX";
-            this.maxStatusLabelX.Size = new System.Drawing.Size(14, 17);
-            this.maxStatusLabelX.Text = "Max";
-            this.maxStatusLabelX.Visible = false;
+            this.maxStatusLabel.Name = "maxStatusLabel";
+            this.maxStatusLabel.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabel.Text = "Max";
+            this.maxStatusLabel.Visible = false;
             // 
-            // autoScaleButtonX
+            // autoScaleButton
             // 
-            this.autoScaleButtonX.Checked = true;
-            this.autoScaleButtonX.CheckOnClick = true;
-            this.autoScaleButtonX.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.autoScaleButtonX.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.autoScaleButtonX.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.autoScaleButtonX.Name = "autoScaleButtonX";
-            this.autoScaleButtonX.Size = new System.Drawing.Size(35, 20);
-            this.autoScaleButtonX.Text = "auto";
-            this.autoScaleButtonX.CheckedChanged += new System.EventHandler(this.autoScaleButtonX_CheckedChanged);
-            // 
-            // scaleStatusLabelY
-            // 
-            this.scaleStatusLabelY.Name = "statusLabelY";
-            this.scaleStatusLabelY.Size = new System.Drawing.Size(47, 17);
-            this.scaleStatusLabelY.Text = "Y:";
-            // 
-            // minStatusLabelY
-            // 
-            this.minStatusLabelY.Name = "minStatusLabelY";
-            this.minStatusLabelY.Size = new System.Drawing.Size(13, 17);
-            this.minStatusLabelY.Text = "min";
-            this.minStatusLabelY.Visible = false;
-            // 
-            // maxStatusLabelY
-            // 
-            this.maxStatusLabelY.Name = "maxStatusLabelY";
-            this.maxStatusLabelY.Size = new System.Drawing.Size(14, 17);
-            this.maxStatusLabelY.Text = "Max";
-            this.maxStatusLabelY.Visible = false;
-            // 
-            // autoScaleButtonY
-            // 
-            this.autoScaleButtonY.Checked = true;
-            this.autoScaleButtonY.CheckOnClick = true;
-            this.autoScaleButtonY.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.autoScaleButtonY.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.autoScaleButtonY.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.autoScaleButtonY.Name = "autoScaleButtonY";
-            this.autoScaleButtonY.Size = new System.Drawing.Size(35, 20);
-            this.autoScaleButtonY.Text = "auto";
-            this.autoScaleButtonY.CheckedChanged += new System.EventHandler(this.autoScaleButtonY_CheckedChanged);
+            this.autoScaleButton.Checked = true;
+            this.autoScaleButton.CheckOnClick = true;
+            this.autoScaleButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButton.Name = "autoScaleButton";
+            this.autoScaleButton.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButton.Text = "auto";
+            this.autoScaleButton.CheckedChanged += new System.EventHandler(this.autoScaleButton_CheckedChanged);
             // 
             // GraphPanelView
             // 
@@ -180,15 +140,11 @@
         #endregion
 
         private System.Windows.Forms.StatusStrip statusStrip;
-        private System.Windows.Forms.ToolStripButton autoScaleButtonX;
-        private System.Windows.Forms.ToolStripButton autoScaleButtonY;
+        private System.Windows.Forms.ToolStripButton autoScaleButton;
         private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
-        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelX;
-        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelX;
-        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelX;
-        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelY;
-        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelY;
-        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
         private System.Windows.Forms.ToolStripStatusLabel spanStatusLabel;

--- a/src/Bonsai.Gui.Visualizers/GraphPanelView.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelView.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+using System.Globalization;
+using System.Drawing;
+
+namespace Bonsai.Gui.Visualizers
+{
+    partial class GraphPanelView : GraphPanel
+    {
+        readonly ToolStripEditableLabel minEditableLabelX;
+        readonly ToolStripEditableLabel maxEditableLabelX;
+        readonly ToolStripEditableLabel minEditableLabelY;
+        readonly ToolStripEditableLabel maxEditableLabelY;
+        readonly ToolStripEditableLabel capacityEditableLabel;
+        readonly ToolStripEditableLabel spanEditableLabel;
+
+        public GraphPanelView()
+        {
+            InitializeComponent();
+            MasterPane = new ViewPane(MasterPane);
+            autoScaleButtonX.Checked = true;
+            autoScaleButtonY.Checked = true;
+            spanEditableLabel = new ToolStripEditableLabel(spanValueLabel, OnSpanEdit);
+            capacityEditableLabel = new ToolStripEditableLabel(capacityValueLabel, OnCapacityEdit);
+            minEditableLabelX = new ToolStripEditableLabel(minStatusLabelX, OnXMinEdit);
+            maxEditableLabelX = new ToolStripEditableLabel(maxStatusLabelX, OnXMaxEdit);
+            minEditableLabelY = new ToolStripEditableLabel(minStatusLabelY, OnYMinEdit);
+            maxEditableLabelY = new ToolStripEditableLabel(maxStatusLabelY, OnYMaxEdit);
+            GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
+            MouseMoveEvent += GraphPanelView_MouseMoveEvent;
+            MouseClick += GraphPanelView_MouseClick;
+            components.Add(spanEditableLabel);
+            components.Add(capacityEditableLabel);
+            components.Add(minEditableLabelX);
+            components.Add(maxEditableLabelX);
+            components.Add(minEditableLabelY);
+            components.Add(maxEditableLabelY);
+        }
+
+        protected StatusStrip StatusStrip
+        {
+            get { return statusStrip; }
+        }
+
+        public bool CanEditCapacity
+        {
+            get { return capacityEditableLabel.Enabled; }
+            set { capacityEditableLabel.Enabled = value; }
+        }
+
+        public bool AutoScaleXVisible
+        {
+            get { return autoScaleButtonX.Visible; }
+            set
+            {
+                autoScaleButtonX.Visible = value;
+                minEditableLabelX.Enabled = value;
+                maxEditableLabelX.Enabled = value;
+            }
+        }
+
+        public bool AutoScaleYVisible
+        {
+            get { return autoScaleButtonY.Visible; }
+            set
+            {
+                autoScaleButtonY.Visible = value;
+                minEditableLabelY.Enabled = value;
+                maxEditableLabelY.Enabled = value;
+            }
+        }
+
+        private bool IsTimeSpan
+        {
+            get
+            {
+                var baseAxis = GraphPane.BarSettings.BarBaseAxis();
+                return baseAxis.Type == AxisType.Date || baseAxis.Type == AxisType.DateAsOrdinal;
+            }
+        }
+
+        public event EventHandler AutoScaleXChanged
+        {
+            add { autoScaleButtonX.CheckedChanged += value; }
+            remove { autoScaleButtonX.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AutoScaleYChanged
+        {
+            add { autoScaleButtonY.CheckedChanged += value; }
+            remove { autoScaleButtonY.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AxisChanged;
+
+        protected virtual void OnAxisChanged(EventArgs e)
+        {
+            AxisChanged?.Invoke(this, e);
+        }
+
+        private bool GraphPanelView_MouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
+        {
+            var pane = MasterPane.FindChartRect(e.Location);
+            if (pane != null)
+            {
+                pane.ReverseTransform(e.Location, out double x, out double y);
+                cursorStatusLabel.Text = string.Format("Cursor: ({0:G5}, {1:G5})", x, y);
+            }
+            return false;
+        }
+
+        private void GraphPanelView_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+                ((ViewPane)MasterPane).StatusGap = statusStrip.Visible ? statusStrip.Height : 0;
+                ZedGraphControl_ReSize(this, EventArgs.Empty);
+            }
+        }
+
+        private void GraphPane_AxisChangeEvent(GraphPane pane)
+        {
+            var span = Span;
+            var capacity = Capacity;
+            var scaleX = pane.XAxis.Scale;
+            var scaleY = pane.YAxis.Scale;
+            autoScaleButtonX.Checked = pane.XAxis.Scale.MaxAuto;
+            autoScaleButtonY.Checked = pane.YAxis.Scale.MaxAuto;
+            spanValueLabel.Text = IsTimeSpan
+                ? TimeSpan.FromDays(span).ToString()
+                : span.ToString("G5", CultureInfo.InvariantCulture);
+            capacityValueLabel.Text = capacity.ToString(CultureInfo.InvariantCulture);
+            minStatusLabelX.Text = scaleX.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabelX.Text = scaleX.Max.ToString("G5", CultureInfo.InvariantCulture);
+            minStatusLabelY.Text = scaleY.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabelY.Text = scaleY.Max.ToString("G5", CultureInfo.InvariantCulture);
+            OnAxisChanged(EventArgs.Empty);
+        }
+
+        private void autoScaleButtonX_CheckedChanged(object sender, EventArgs e)
+        {
+            AutoScaleX = autoScaleButtonX.Checked;
+            minStatusLabelX.Visible = !autoScaleButtonX.Checked;
+            maxStatusLabelX.Visible = !autoScaleButtonX.Checked;
+        }
+
+        private void autoScaleButtonY_CheckedChanged(object sender, EventArgs e)
+        {
+            AutoScaleY = autoScaleButtonY.Checked;
+            minStatusLabelY.Visible = !autoScaleButtonY.Checked;
+            maxStatusLabelY.Visible = !autoScaleButtonY.Checked;
+        }
+
+        private void OnSpanEdit(string text)
+        {
+            if (IsTimeSpan)
+            {
+                if (TimeSpan.TryParse(text, out TimeSpan timeSpan))
+                {
+                    Span = timeSpan.TotalDays;
+                }
+            }
+            else if (double.TryParse(text, out double span))
+            {
+                Span = span;
+            }
+        }
+
+        private void OnCapacityEdit(string text)
+        {
+            if (int.TryParse(text, out int capacity))
+            {
+                Capacity = capacity;
+            }
+        }
+
+        private void OnXMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                XMin = min;
+            }
+        }
+
+        private void OnXMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                XMax = max;
+            }
+        }
+
+        private void OnYMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                YMin = min;
+            }
+        }
+
+        private void OnYMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                YMax = max;
+            }
+        }
+
+        class ViewPane : MasterPane
+        {
+            public ViewPane(MasterPane masterPane)
+                : base(masterPane.Title.Text, masterPane.Rect)
+            {
+                Margin.All = 0;
+                Title.IsVisible = false;
+                Add(masterPane.PaneList[0]);
+            }
+
+            public float StatusGap { get; set; }
+
+            public override void ReSize(Graphics g, RectangleF rect)
+            {
+                rect.Height -= StatusGap;
+                base.ReSize(g, rect);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanelView.resx
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
 using Bonsai.Design;
 using ZedGraph;
@@ -15,14 +14,6 @@ namespace Bonsai.Gui.Visualizers
         Type indexType;
         BarSettings barSettings;
         GraphPanelBuilder graphBuilder;
-
-        static void ThrowIfNotEquals<T>(T left, T right, string message)
-        {
-            if (!EqualityComparer<T>.Default.Equals(left, right))
-            {
-                throw new InvalidOperationException(message);
-            }
-        }
 
         internal Axis BarBaseAxis()
         {
@@ -50,7 +41,7 @@ namespace Bonsai.Gui.Visualizers
                     GraphHelper.FormatLinearDateAxis(baseAxis);
                 }
             }
-            else ThrowIfNotEquals(indexType, type, "Only overlays with identical axis are allowed.");
+            else ThrowHelper.ThrowIfNotEquals(indexType, type, "Only overlays with identical axis are allowed.");
         }
 
         internal void EnsureBarSettings(BarSettings settings)
@@ -68,12 +59,12 @@ namespace Bonsai.Gui.Visualizers
             else
             {
                 const string ErrorMessage = "All bar graph overlays must have identical settings.";
-                ThrowIfNotEquals(barSettings.Base, settings.Base, ErrorMessage);
-                ThrowIfNotEquals(barSettings.ClusterScaleWidth, settings.ClusterScaleWidth, ErrorMessage);
-                ThrowIfNotEquals(barSettings.ClusterScaleWidthAuto, settings.ClusterScaleWidthAuto, ErrorMessage);
-                ThrowIfNotEquals(barSettings.MinBarGap, settings.MinBarGap, ErrorMessage);
-                ThrowIfNotEquals(barSettings.MinClusterGap, settings.MinClusterGap, ErrorMessage);
-                ThrowIfNotEquals(barSettings.Type, settings.Type, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.Base, settings.Base, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.ClusterScaleWidth, settings.ClusterScaleWidth, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.ClusterScaleWidthAuto, settings.ClusterScaleWidthAuto, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.MinBarGap, settings.MinBarGap, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.MinClusterGap, settings.MinClusterGap, ErrorMessage);
+                ThrowHelper.ThrowIfNotEquals(barSettings.Type, settings.Type, ErrorMessage);
             }
         }
 

--- a/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
@@ -71,7 +71,7 @@ namespace Bonsai.Gui.Visualizers
         /// <inheritdoc/>
         protected override GraphControl CreateControl(IServiceProvider provider, GraphPanelBuilder builder)
         {
-            var graph = new GraphControl();
+            var graph = new GraphPanelView();
             graph.Dock = DockStyle.Fill;
             graphBuilder = builder;
             return graph;

--- a/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
@@ -91,6 +91,8 @@ namespace Bonsai.Gui.Visualizers
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             var graphPanelBuilder = (GraphPanelBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
             var controller = graphPanelBuilder.Controller;
+            view.GraphPane.XAxis.Scale.IsReverse = controller.ReverseX;
+            view.GraphPane.YAxis.Scale.IsReverse = controller.ReverseY;
             barSettings = view.GraphPane.BarSettings;
             barSettings.Base = controller.BaseAxis;
             barSettings.Type = controller.BarType;

--- a/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelVisualizer.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Bonsai.Design;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer that can be used to overlay multiple plots sharing
+    /// the same axes in a single graph panel.
+    /// </summary>
+    public class GraphPanelVisualizer : MashupControlVisualizerBase<GraphControl, GraphPanelBuilder>
+    {
+        Type indexType;
+        BarSettings barSettings;
+        GraphPanelBuilder graphBuilder;
+
+        static void ThrowIfNotEquals<T>(T left, T right, string message)
+        {
+            if (!EqualityComparer<T>.Default.Equals(left, right))
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        internal Axis BarBaseAxis()
+        {
+            return graphBuilder.BaseAxis switch
+            {
+                BarBase.Y => Control.GraphPane.YAxis,
+                BarBase.Y2 => Control.GraphPane.Y2Axis,
+                BarBase.X2 => Control.GraphPane.X2Axis,
+                _ => Control.GraphPane.XAxis
+            };
+        }
+
+        internal void EnsureIndex(Type type)
+        {
+            if (indexType == null)
+            {
+                indexType = type;
+                var baseAxis = BarBaseAxis();
+                if (type == typeof(string))
+                {
+                    GraphHelper.FormatOrdinalAxis(baseAxis, indexType);
+                }
+                if (type == typeof(XDate))
+                {
+                    GraphHelper.FormatLinearDateAxis(baseAxis);
+                }
+            }
+            else ThrowIfNotEquals(indexType, type, "Only overlays with identical axis are allowed.");
+        }
+
+        internal void EnsureBarSettings(BarSettings settings)
+        {
+            if (barSettings == null)
+            {
+                barSettings = Control.GraphPane.BarSettings;
+                barSettings.Base = settings.Base;
+                barSettings.ClusterScaleWidth = settings.ClusterScaleWidth;
+                barSettings.ClusterScaleWidthAuto = settings.ClusterScaleWidthAuto;
+                barSettings.MinBarGap = settings.MinBarGap;
+                barSettings.MinClusterGap = settings.MinClusterGap;
+                barSettings.Type = settings.Type;
+            }
+            else
+            {
+                const string ErrorMessage = "All bar graph overlays must have identical settings.";
+                ThrowIfNotEquals(barSettings.Base, settings.Base, ErrorMessage);
+                ThrowIfNotEquals(barSettings.ClusterScaleWidth, settings.ClusterScaleWidth, ErrorMessage);
+                ThrowIfNotEquals(barSettings.ClusterScaleWidthAuto, settings.ClusterScaleWidthAuto, ErrorMessage);
+                ThrowIfNotEquals(barSettings.MinBarGap, settings.MinBarGap, ErrorMessage);
+                ThrowIfNotEquals(barSettings.MinClusterGap, settings.MinClusterGap, ErrorMessage);
+                ThrowIfNotEquals(barSettings.Type, settings.Type, ErrorMessage);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override GraphControl CreateControl(IServiceProvider provider, GraphPanelBuilder builder)
+        {
+            var graph = new GraphControl();
+            graph.Dock = DockStyle.Fill;
+            graphBuilder = builder;
+            return graph;
+        }
+
+        /// <inheritdoc/>
+        protected override void LoadMashupSource(int index, MashupSource mashupSource, IServiceProvider provider)
+        {
+            Control.ResetColorCycle();
+            base.LoadMashupSource(index, mashupSource, provider);
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            base.Unload();
+            indexType = null;
+            barSettings = null;
+            graphBuilder = null;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraph.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraph.cs
@@ -1,0 +1,23 @@
+﻿using System.Drawing;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    class LineGraph : RollingGraph
+    {
+        public SymbolType SymbolType { get; set; } = SymbolType.None;
+
+        public float LineWidth { get; set; } = 1;
+
+        internal override CurveItem CreateSeries(string label, IPointListEdit points, Color color)
+        {
+            var curve = new LineItem(label, points, color, SymbolType, LineWidth);
+            curve.Line.IsAntiAlias = true;
+            curve.Line.IsOptimizedDraw = true;
+            curve.Label.IsVisible = !string.IsNullOrEmpty(label);
+            curve.Symbol.Fill.Type = FillType.Solid;
+            curve.Symbol.IsAntiAlias = true;
+            return curve;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphBuilder.cs
@@ -47,35 +47,35 @@ namespace Bonsai.Gui.Visualizers
         public int? Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed lower limit for the x-axis range.
+        /// Gets or sets a value specifying a fixed lower limit for the X-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed lower limit of the x-axis range.")]
+        [Description("Specifies the optional fixed lower limit of the X-axis range.")]
         public double? XMin { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed upper limit for the x-axis range.
+        /// Gets or sets a value specifying a fixed upper limit for the X-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed upper limit of the x-axis range.")]
+        [Description("Specifies the optional fixed upper limit of the X-axis range.")]
         public double? XMax { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed lower limit for the Y-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        [Description("Specifies the optional fixed lower limit of the Y-axis range.")]
         public double? YMin { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed upper limit for the Y-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        [Description("Specifies the optional fixed upper limit of the Y-axis range.")]
         public double? YMax { get; set; }
 
         internal VisualizerController Controller { get; set; }

--- a/src/Bonsai.Gui.Visualizers/LineGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphBuilder.cs
@@ -1,0 +1,137 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that configures a visualizer to plot each element
+    /// of the sequence as a line graph.
+    /// </summary>
+    [DefaultProperty(nameof(ValueSelector))]
+    [TypeVisualizer(typeof(LineGraphVisualizer))]
+    [Description("A visualizer that plots each element of the sequence as a line graph.")]
+    public class LineGraphBuilder : SingleArgumentExpressionBuilder
+    {
+        /// <summary>
+        /// Gets or sets the names of the properties to be displayed in the graph.
+        /// Each selected property must have a point pair compatible type.
+        /// </summary>
+        [Editor("Bonsai.Design.MultiMemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The names of the properties to be displayed in the graph. Each selected property must have a point pair compatible type.")]
+        public string ValueSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional symbol type to use for the line graph.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The optional symbol type to use for the line graph.")]
+        public SymbolType SymbolType { get; set; } = SymbolType.None;
+
+        /// <summary>
+        /// Gets or sets the width, in points, to be used for the line graph. Use a value of zero to hide the line.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The width, in points, to be used for the line graph. Use a value of zero to hide the line.")]
+        public float LineWidth { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.")]
+        public int? Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the x-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the x-axis range.")]
+        public double? XMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the x-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the x-axis range.")]
+        public double? XMax { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        public double? YMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        public double? YMax { get; set; }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal int? Capacity;
+            internal double? XMin;
+            internal double? XMax;
+            internal double? YMin;
+            internal double? YMax;
+            internal bool LabelAxes;
+            internal string[] ValueLabels;
+            internal SymbolType SymbolType;
+            internal float LineWidth;
+            internal Action<object, LineGraphVisualizer> AddValues;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// line graph visualizer on the specified input argument.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var parameterType = source.Type.GetGenericArguments()[0];
+            var valueParameter = Expression.Parameter(typeof(object));
+            var viewParameter = Expression.Parameter(typeof(LineGraphVisualizer));
+            var elementVariable = Expression.Variable(parameterType);
+            Controller = new VisualizerController
+            {
+                Capacity = Capacity,
+                XMin = XMin,
+                XMax = XMax,
+                YMin = YMin,
+                YMax = YMax,
+                SymbolType = SymbolType,
+                LineWidth = LineWidth
+            };
+
+            var selectedValues = GraphHelper.SelectDataPoints(
+                elementVariable,
+                ValueSelector,
+                out Controller.ValueLabels,
+                out Controller.LabelAxes);
+            var addValuesBody = Expression.Block(new[] { elementVariable },
+                Expression.Assign(elementVariable, Expression.Convert(valueParameter, parameterType)),
+                Expression.Call(viewParameter, nameof(LineGraphVisualizer.AddValues), null, selectedValues));
+            Controller.AddValues = Expression.Lambda<Action<object, LineGraphVisualizer>>(addValuesBody, valueParameter, viewParameter).Compile();
+            return Expression.Call(typeof(LineGraphBuilder), nameof(Process), new[] { parameterType }, source);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraphView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphView.Designer.cs
@@ -1,0 +1,199 @@
+﻿namespace Bonsai.Gui.Visualizers
+{
+    partial class LineGraphView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButtonX = new System.Windows.Forms.ToolStripButton();
+            this.autoScaleButtonY = new System.Windows.Forms.ToolStripButton();
+            this.graph = new Bonsai.Gui.Visualizers.LineGraph();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.capacityStatusLabel,
+            this.capacityValueLabel,
+            this.scaleStatusLabelX,
+            this.minStatusLabelX,
+            this.maxStatusLabelX,
+            this.autoScaleButtonX,
+            this.scaleStatusLabelY,
+            this.minStatusLabelY,
+            this.maxStatusLabelY,
+            this.autoScaleButtonY});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip1";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // capacityStatusLabel
+            // 
+            this.capacityStatusLabel.Name = "capacityStatusLabel";
+            this.capacityStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.capacityStatusLabel.Text = "Capacity:";
+            // 
+            // capacityValueLabel
+            // 
+            this.capacityValueLabel.Name = "capacityValueLabel";
+            this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.capacityValueLabel.Text = "count";
+            // 
+            // scaleStatusLabelX
+            // 
+            this.scaleStatusLabelX.Name = "statusLabelX";
+            this.scaleStatusLabelX.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelX.Text = "X:";
+            // 
+            // minStatusLabelX
+            // 
+            this.minStatusLabelX.Name = "minStatusLabelX";
+            this.minStatusLabelX.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelX.Text = "min";
+            this.minStatusLabelX.Visible = false;
+            // 
+            // maxStatusLabelX
+            // 
+            this.maxStatusLabelX.Name = "maxStatusLabelX";
+            this.maxStatusLabelX.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelX.Text = "Max";
+            this.maxStatusLabelX.Visible = false;
+            // 
+            // autoScaleButtonX
+            // 
+            this.autoScaleButtonX.Checked = true;
+            this.autoScaleButtonX.CheckOnClick = true;
+            this.autoScaleButtonX.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonX.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonX.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonX.Name = "autoScaleButtonX";
+            this.autoScaleButtonX.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonX.Text = "auto";
+            this.autoScaleButtonX.CheckedChanged += new System.EventHandler(this.autoScaleButtonX_CheckedChanged);
+            // 
+            // scaleStatusLabelY
+            // 
+            this.scaleStatusLabelY.Name = "statusLabelY";
+            this.scaleStatusLabelY.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelY.Text = "Y:";
+            // 
+            // minStatusLabelY
+            // 
+            this.minStatusLabelY.Name = "minStatusLabelY";
+            this.minStatusLabelY.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelY.Text = "min";
+            this.minStatusLabelY.Visible = false;
+            // 
+            // maxStatusLabelY
+            // 
+            this.maxStatusLabelY.Name = "maxStatusLabelY";
+            this.maxStatusLabelY.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelY.Text = "Max";
+            this.maxStatusLabelY.Visible = false;
+            // 
+            // autoScaleButtonY
+            // 
+            this.autoScaleButtonY.Checked = true;
+            this.autoScaleButtonY.CheckOnClick = true;
+            this.autoScaleButtonY.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonY.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonY.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonY.Name = "autoScaleButtonY";
+            this.autoScaleButtonY.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonY.Text = "auto";
+            this.autoScaleButtonY.CheckedChanged += new System.EventHandler(this.autoScaleButtonY_CheckedChanged);
+            // 
+            // graph
+            // 
+            this.graph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.graph.Location = new System.Drawing.Point(0, 0);
+            this.graph.Name = "graph";
+            this.graph.ScrollGrace = 0D;
+            this.graph.ScrollMaxX = 0D;
+            this.graph.ScrollMaxY = 0D;
+            this.graph.ScrollMaxY2 = 0D;
+            this.graph.ScrollMinX = 0D;
+            this.graph.ScrollMinY = 0D;
+            this.graph.ScrollMinY2 = 0D;
+            this.graph.Size = new System.Drawing.Size(400, 218);
+            this.graph.TabIndex = 2;
+            this.graph.MouseMoveEvent += new ZedGraph.ZedGraphControl.ZedMouseEventHandler(this.graph_MouseMoveEvent);
+            this.graph.MouseClick += new System.Windows.Forms.MouseEventHandler(this.graph_MouseClick);
+            // 
+            // LineGraphView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.graph);
+            this.Controls.Add(this.statusStrip);
+            this.Name = "LineGraphView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonX;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonY;
+        private LineGraph graph;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraphView.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphView.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+using System.Globalization;
+
+namespace Bonsai.Gui.Visualizers
+{
+    partial class LineGraphView : UserControl
+    {
+        readonly ToolStripEditableLabel minEditableLabelX;
+        readonly ToolStripEditableLabel maxEditableLabelX;
+        readonly ToolStripEditableLabel minEditableLabelY;
+        readonly ToolStripEditableLabel maxEditableLabelY;
+        readonly ToolStripEditableLabel capacityEditableLabel;
+
+        public LineGraphView()
+        {
+            InitializeComponent();
+            autoScaleButtonX.Checked = true;
+            autoScaleButtonY.Checked = true;
+            capacityEditableLabel = new ToolStripEditableLabel(capacityValueLabel, OnCapacityEdit);
+            minEditableLabelX = new ToolStripEditableLabel(minStatusLabelX, OnXMinEdit);
+            maxEditableLabelX = new ToolStripEditableLabel(maxStatusLabelX, OnXMaxEdit);
+            minEditableLabelY = new ToolStripEditableLabel(minStatusLabelY, OnYMinEdit);
+            maxEditableLabelY = new ToolStripEditableLabel(maxStatusLabelY, OnYMaxEdit);
+            Graph.GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
+            components.Add(capacityEditableLabel);
+            components.Add(minEditableLabelX);
+            components.Add(maxEditableLabelX);
+            components.Add(minEditableLabelY);
+            components.Add(maxEditableLabelY);
+        }
+
+        protected StatusStrip StatusStrip
+        {
+            get { return statusStrip; }
+        }
+
+        public LineGraph Graph
+        {
+            get { return graph; }
+        }
+
+        public int NumSeries
+        {
+            get { return graph.NumSeries; }
+            set { graph.EnsureCapacity(value); }
+        }
+
+        public virtual int Capacity
+        {
+            get { return graph.Capacity; }
+            set { graph.Capacity = value; }
+        }
+
+        public bool CanEditCapacity
+        {
+            get { return capacityEditableLabel.Enabled; }
+            set { capacityEditableLabel.Enabled = value; }
+        }
+
+        public double XMin
+        {
+            get { return graph.XMin; }
+            set { graph.XMin = value; }
+        }
+
+        public double XMax
+        {
+            get { return graph.XMax; }
+            set { graph.XMax = value; }
+        }
+
+        public double YMin
+        {
+            get { return graph.YMin; }
+            set { graph.YMin = value; }
+        }
+
+        public double YMax
+        {
+            get { return graph.YMax; }
+            set { graph.YMax = value; }
+        }
+
+        public bool AutoScaleX
+        {
+            get { return autoScaleButtonX.Checked; }
+            set { autoScaleButtonX.Checked = value; }
+        }
+
+        public bool AutoScaleY
+        {
+            get { return autoScaleButtonY.Checked; }
+            set { autoScaleButtonY.Checked = value; }
+        }
+
+        public bool AutoScaleXVisible
+        {
+            get { return autoScaleButtonX.Visible; }
+            set
+            {
+                autoScaleButtonX.Visible = value;
+                minEditableLabelX.Enabled = value;
+                maxEditableLabelX.Enabled = value;
+            }
+        }
+
+        public bool AutoScaleYVisible
+        {
+            get { return autoScaleButtonY.Visible; }
+            set
+            {
+                autoScaleButtonY.Visible = value;
+                minEditableLabelY.Enabled = value;
+                maxEditableLabelY.Enabled = value;
+            }
+        }
+
+        public event EventHandler AutoScaleXChanged
+        {
+            add { autoScaleButtonX.CheckedChanged += value; }
+            remove { autoScaleButtonX.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AutoScaleYChanged
+        {
+            add { autoScaleButtonY.CheckedChanged += value; }
+            remove { autoScaleButtonY.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AxisChanged;
+
+        protected virtual void OnAxisChanged(EventArgs e)
+        {
+            AxisChanged?.Invoke(this, e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            graph.EnsureCapacity(NumSeries);
+            base.OnLoad(e);
+        }
+
+        private bool graph_MouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
+        {
+            var pane = graph.MasterPane.FindChartRect(e.Location);
+            if (pane != null)
+            {
+                pane.ReverseTransform(e.Location, out double x, out double y);
+                cursorStatusLabel.Text = string.Format("Cursor: ({0:G5}, {1:G5})", x, y);
+            }
+            return false;
+        }
+
+        private void graph_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+            }
+        }
+
+        private void GraphPane_AxisChangeEvent(GraphPane pane)
+        {
+            var capacity = graph.Capacity;
+            var scaleX = pane.XAxis.Scale;
+            var scaleY = pane.YAxis.Scale;
+            autoScaleButtonX.Checked = pane.XAxis.Scale.MaxAuto;
+            autoScaleButtonY.Checked = pane.YAxis.Scale.MaxAuto;
+            capacityValueLabel.Text = capacity.ToString(CultureInfo.InvariantCulture);
+            minStatusLabelX.Text = scaleX.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabelX.Text = scaleX.Max.ToString("G5", CultureInfo.InvariantCulture);
+            minStatusLabelY.Text = scaleY.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabelY.Text = scaleY.Max.ToString("G5", CultureInfo.InvariantCulture);
+            OnAxisChanged(EventArgs.Empty);
+        }
+
+        private void autoScaleButtonX_CheckedChanged(object sender, EventArgs e)
+        {
+            graph.AutoScaleX = autoScaleButtonX.Checked;
+            minStatusLabelX.Visible = !autoScaleButtonX.Checked;
+            maxStatusLabelX.Visible = !autoScaleButtonX.Checked;
+        }
+
+        private void autoScaleButtonY_CheckedChanged(object sender, EventArgs e)
+        {
+            graph.AutoScaleY = autoScaleButtonY.Checked;
+            minStatusLabelY.Visible = !autoScaleButtonY.Checked;
+            maxStatusLabelY.Visible = !autoScaleButtonY.Checked;
+        }
+
+        private void OnCapacityEdit(string text)
+        {
+            if (int.TryParse(text, out int capacity))
+            {
+                Capacity = capacity;
+            }
+        }
+
+        private void OnXMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                XMin = min;
+            }
+        }
+
+        private void OnXMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                XMax = max;
+            }
+        }
+
+        private void OnYMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                YMin = min;
+            }
+        }
+
+        private void OnYMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                YMax = max;
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraphView.resx
+++ b/src/Bonsai.Gui.Visualizers/LineGraphView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
@@ -1,0 +1,180 @@
+﻿using Bonsai.Design;
+using Bonsai.Expressions;
+using System;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display an object as a line graph.
+    /// </summary>
+    public class LineGraphVisualizer : BufferedVisualizer
+    {
+        LineGraphBuilder.VisualizerController controller;
+        LineGraphView view;
+        bool labelLines;
+        bool reset;
+
+        /// <summary>
+        /// Gets or sets the maximum number of points displayed at any one moment in the graph.
+        /// </summary>
+        public int Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower limit of the x-axis range when using a fixed scale.
+        /// </summary>
+        public double XMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper limit of the x-axis range when using a fixed scale.
+        /// </summary>
+        public double XMax { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double YMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double YMax { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the x-axis range should be recalculated
+        /// automatically as the graph updates.
+        /// </summary>
+        public bool AutoScaleX { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// automatically as the graph updates.
+        /// </summary>
+        public bool AutoScaleY { get; set; } = true;
+
+        internal void AddValues(PointPair[] values)
+        {
+            if (view.Graph.NumSeries != values.Length || reset)
+            {
+                view.Graph.EnsureCapacity(
+                    values.Length,
+                    labelLines ? controller.ValueLabels : null,
+                    reset);
+                reset = false;
+            }
+            view.Graph.AddValues(values);
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var lineChartBuilder = (LineGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = lineChartBuilder.Controller;
+
+            view = new LineGraphView();
+            view.Dock = DockStyle.Fill;
+            view.Graph.LineWidth = controller.LineWidth;
+            view.Graph.SymbolType = controller.SymbolType;
+            labelLines = controller.ValueLabels != null;
+            if (labelLines && controller.LabelAxes && controller.ValueLabels.Length == 2)
+            {
+                labelLines = false;
+                GraphHelper.SetAxisLabel(view.Graph.GraphPane.XAxis, controller.ValueLabels[0]);
+                GraphHelper.SetAxisLabel(view.Graph.GraphPane.YAxis, controller.ValueLabels[1]);
+            }
+
+            if (labelLines)
+            {
+                view.Graph.EnsureCapacity(
+                    controller.ValueLabels.Length,
+                    labelLines ? controller.ValueLabels : null);
+            }
+
+            if (controller.XMin.HasValue || controller.XMax.HasValue)
+            {
+                view.AutoScaleX = false;
+                view.AutoScaleXVisible = false;
+                view.XMin = controller.XMin.GetValueOrDefault();
+                view.XMax = controller.XMax.GetValueOrDefault();
+            }
+            else
+            {
+                view.AutoScaleX = AutoScaleX;
+                if (!AutoScaleX)
+                {
+                    view.XMin = XMin;
+                    view.XMax = XMax;
+                }
+            }
+
+            if (controller.YMin.HasValue || controller.YMax.HasValue)
+            {
+                view.AutoScaleY = false;
+                view.AutoScaleYVisible = false;
+                view.YMin = controller.YMin.GetValueOrDefault();
+                view.YMax = controller.YMax.GetValueOrDefault();
+            }
+            else
+            {
+                view.AutoScaleY = AutoScaleY;
+                if (!AutoScaleY)
+                {
+                    view.YMin = YMin;
+                    view.YMax = YMax;
+                }
+            }
+
+            if (controller.Capacity.HasValue)
+            {
+                view.Capacity = controller.Capacity.Value;
+                view.CanEditCapacity = false;
+            }
+            else
+            {
+                view.Capacity = Capacity;
+                view.CanEditCapacity = true;
+            }
+
+            view.HandleDestroyed += delegate
+            {
+                XMin = view.XMin;
+                XMax = view.XMax;
+                YMin = view.YMin;
+                YMax = view.YMax;
+                AutoScaleX = view.AutoScaleX;
+                AutoScaleY = view.AutoScaleY;
+                Capacity = view.Capacity;
+            };
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(view);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            controller.AddValues(value, this);
+            view.Graph.Invalidate();
+        }
+
+        /// <inheritdoc/>
+        public override void SequenceCompleted()
+        {
+            reset = true;
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            view.Dispose();
+            view = null;
+            controller = null;
+            reset = false;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
@@ -24,33 +24,33 @@ namespace Bonsai.Gui.Visualizers
         public int Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets the lower limit of the x-axis range when using a fixed scale.
+        /// Gets or sets the lower limit of the X-axis range when using a fixed scale.
         /// </summary>
         public double XMin { get; set; }
 
         /// <summary>
-        /// Gets or sets the upper limit of the x-axis range when using a fixed scale.
+        /// Gets or sets the upper limit of the X-axis range when using a fixed scale.
         /// </summary>
         public double XMax { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the lower limit of the Y-axis range when using a fixed scale.
         /// </summary>
         public double YMin { get; set; }
 
         /// <summary>
-        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the upper limit of the Y-axis range when using a fixed scale.
         /// </summary>
         public double YMax { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the x-axis range should be recalculated
+        /// Gets or sets a value indicating whether the X-axis range should be recalculated
         /// automatically as the graph updates.
         /// </summary>
         public bool AutoScaleX { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// Gets or sets a value indicating whether the Y-axis range should be recalculated
         /// automatically as the graph updates.
         /// </summary>
         public bool AutoScaleY { get; set; } = true;

--- a/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
@@ -1,6 +1,8 @@
 ﻿using Bonsai.Design;
 using Bonsai.Expressions;
 using System;
+using System.Collections.Generic;
+using System.Reactive;
 using System.Windows.Forms;
 using ZedGraph;
 
@@ -159,7 +161,16 @@ namespace Bonsai.Gui.Visualizers
         public override void Show(object value)
         {
             controller.AddValues(value, this);
-            view.Graph.Invalidate();
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
+            {
+                view.Graph.Invalidate();
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui.Visualizers/PointPairDeque.cs
+++ b/src/Bonsai.Gui.Visualizers/PointPairDeque.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    internal class PointPairDeque : IReadOnlyList<PointPair>
+    {
+        int head;
+        int tail;
+        int count;
+        PointPair[] buffer;
+
+        public PointPairDeque() : this(capacity: 4)
+        {
+        }
+
+        public PointPairDeque(int capacity)
+        {
+            if (capacity < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRange(nameof(capacity));
+            }
+
+            EnsureCapacity(capacity);
+        }
+
+        private void EnsureCapacity(int capacity)
+        {
+            var array = new PointPair[capacity];
+            if (count > 0)
+            {
+                if (head < tail)
+                {
+                    Array.Copy(buffer, head, array, 0, count);
+                }
+                else
+                {
+                    Array.Copy(buffer, head, array, 0, buffer.Length - head);
+                    Array.Copy(buffer, 0, array, buffer.Length - head, tail);
+                }
+            }
+
+            for (int i = count; i < array.Length; i++)
+            {
+                array[i] = new PointPair();
+            }
+
+            buffer = array;
+            head = 0;
+            tail = count;
+        }
+
+        private int GetIndexInternal(int index)
+        {
+            return (head + index) % buffer.Length;
+        }
+
+        public PointPair this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= count)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRange(nameof(index));
+                }
+
+                return buffer[GetIndexInternal(index)];
+            }
+            set
+            {
+                if (index < 0 || index >= count)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRange(nameof(index));
+                }
+
+                buffer[GetIndexInternal(index)] = value;
+            }
+        }
+
+        public int Count => count;
+
+        public void Enqueue(PointPair point)
+        {
+            Enqueue(point.X, point.Y, 0, null);
+        }
+
+        public void Enqueue(double x, double y)
+        {
+            Enqueue(x, y, 0, null);
+        }
+
+        public void Enqueue(double x, double y, double z, object tag)
+        {
+            if (count >= buffer.Length)
+            {
+                EnsureCapacity(buffer.Length * 2);
+            }
+
+            buffer[tail].X = x;
+            buffer[tail].Y = y;
+            buffer[tail].Z = z;
+            buffer[tail].Tag = tag;
+            tail = (tail + 1) % buffer.Length;
+            count++;
+        }
+
+        public bool TryDequeue(out PointPair result)
+        {
+            if (count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = buffer[head];
+            buffer[head].Tag = default;
+            head = (head + 1) % buffer.Length;
+            count--;
+            return true;
+        }
+
+        public bool TryDequeueLast(out PointPair result)
+        {
+            if (count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            var index = tail - 1;
+            if (index < 0) index += buffer.Length;
+            result = buffer[index];
+            buffer[index].Tag = default;
+            tail = index;
+            count--;
+            return true;
+        }
+
+        public void Clear()
+        {
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                buffer[i].Tag = default;
+            }
+            head = 0;
+            tail = 0;
+            count = 0;
+        }
+
+        public IEnumerator<PointPair> GetEnumerator()
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return buffer[GetIndexInternal(i)];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraph.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraph.cs
@@ -1,0 +1,260 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    abstract class RollingGraph : GraphControl
+    {
+        int capacity;
+        int numSeries;
+        bool autoScaleX;
+        bool autoScaleY;
+        IPointListEdit[] series;
+        RollingPointPairList[] rollingSeries;
+        const int DefaultCapacity = 640;
+        const int DefaultNumSeries = 1;
+
+        public RollingGraph()
+        {
+            autoScaleX = true;
+            autoScaleY = true;
+            IsShowContextMenu = false;
+            capacity = DefaultCapacity;
+            numSeries = DefaultNumSeries;
+            ZoomEvent += RollingGraph_ZoomEvent;
+        }
+
+        protected IPointListEdit[] Series
+        {
+            get { return series; }
+        }
+
+        public int NumSeries
+        {
+            get { return numSeries; }
+        }
+
+        public int Capacity
+        {
+            get { return capacity; }
+            set
+            {
+                capacity = value;
+                EnsureCapacity(numSeries);
+                Invalidate();
+            }
+        }
+
+        public double XMin
+        {
+            get { return GraphPane.XAxis.Scale.Min; }
+            set
+            {
+                GraphPane.XAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double XMax
+        {
+            get { return GraphPane.XAxis.Scale.Max; }
+            set
+            {
+                GraphPane.XAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMin
+        {
+            get { return GraphPane.YAxis.Scale.Min; }
+            set
+            {
+                GraphPane.YAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMax
+        {
+            get { return GraphPane.YAxis.Scale.Max; }
+            set
+            {
+                GraphPane.YAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public bool AutoScaleX
+        {
+            get { return autoScaleX; }
+            set
+            {
+                var changed = autoScaleX != value;
+                autoScaleX = value;
+                if (changed)
+                {
+                    GraphPane.XAxis.Scale.MaxAuto = autoScaleX;
+                    GraphPane.XAxis.Scale.MinAuto = autoScaleX;
+                    if (autoScaleX) Invalidate();
+                }
+            }
+        }
+
+        public bool AutoScaleY
+        {
+            get { return autoScaleY; }
+            set
+            {
+                var changed = autoScaleY != value;
+                autoScaleY = value;
+                if (changed)
+                {
+                    GraphPane.YAxis.Scale.MaxAuto = autoScaleY;
+                    GraphPane.YAxis.Scale.MinAuto = autoScaleY;
+                    if (autoScaleY) Invalidate();
+                }
+            }
+        }
+
+        internal abstract CurveItem CreateSeries(string label, IPointListEdit points, Color color);
+
+        private void EnsureSeries(string[] labels)
+        {
+            var hasLabels = labels != null;
+            if (GraphPane.CurveList.Count != series.Length)
+            {
+                ResetColorCycle();
+                GraphPane.CurveList.Clear();
+                for (int i = 0; i < series.Length; i++)
+                {
+                    var curve = CreateSeries(
+                        label: hasLabels ? labels[i] : string.Empty,
+                        points: series[i],
+                        color: GetNextColor());
+                    GraphPane.CurveList.Add(curve);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < series.Length; i++)
+                {
+                    GraphPane.CurveList[i].Points = series[i];
+                }
+            }
+        }
+
+        public void EnsureCapacity(int count, string[] labels = null, bool reset = false)
+        {
+            numSeries = count;
+            if (series == null || series.Length != numSeries || reset)
+            {
+                if (capacity == 0)
+                {
+                    rollingSeries = null;
+                    series = new IPointListEdit[numSeries];
+                }
+                else
+                {
+                    rollingSeries = new RollingPointPairList[numSeries];
+                    series = rollingSeries;
+                }
+            }
+
+            var previousSeries = series;
+            if (capacity == 0 && rollingSeries != null)
+            {
+                rollingSeries = null;
+                series = new IPointListEdit[numSeries];
+            }
+
+            for (int i = 0; i < series.Length; i++)
+            {
+                var previousPoints = previousSeries[i];
+                if (capacity > 0)
+                {
+                    var points = new RollingPointPairList(capacity);
+                    if (previousPoints != null)
+                    {
+                        points.Add(previousPoints);
+                    }
+
+                    series[i] = points;
+                }
+                else
+                {
+                    var points = new PointPairList();
+                    if (previousPoints != null)
+                    {
+                        for (int p = 0; p < previousPoints.Count; p++)
+                        {
+                            points.Add(previousPoints[p]);
+                        }
+                    }
+
+                    series[i] = points;
+                }
+            }
+
+            EnsureSeries(labels);
+        }
+
+        public void AddValues(double index, params double[] values) => AddValues(index, null, values);
+
+        public void AddValues(double index, object tag, params double[] values)
+        {
+            if (rollingSeries != null)
+            {
+                for (int i = 0; i < rollingSeries.Length; i++)
+                {
+                    rollingSeries[i].Add(index, values[i], tag);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < series.Length; i++)
+                {
+                    series[i].Add(new PointPair(index, values[i], double.MaxValue, tag));
+                }
+            }
+        }
+
+        public void AddValues(params PointPair[] values)
+        {
+            for (int i = 0; i < series.Length; i++)
+            {
+                series[i].Add(values[i]);
+            }
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.P)
+            {
+                DoPrint();
+            }
+
+            if (e.Modifiers == Keys.Control && e.KeyCode == Keys.S)
+            {
+                SaveAs();
+            }
+
+            if (e.KeyCode == Keys.Back)
+            {
+                ZoomOut(GraphPane);
+            }
+
+            base.OnKeyDown(e);
+        }
+
+        private void RollingGraph_ZoomEvent(ZedGraphControl sender, ZoomState oldState, ZoomState newState)
+        {
+            MasterPane.AxisChange();
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
@@ -77,26 +77,6 @@ namespace Bonsai.Gui.Visualizers
         [Description("Specifies the optional fixed upper limit of the y-axis range.")]
         public double? Max { get; set; }
 
-        /// <summary>
-        /// Gets a value indicating whether to serialize the element selector property.
-        /// </summary>
-        /// <returns>
-        /// This method always returns <see langword="false"/> as this is an obsolete property.
-        /// </returns>
-        [Obsolete]
-        public bool ShouldSerializeElementSelector() => false;
-
-        /// <summary>
-        /// Gets or sets the names of the properties that will be displayed in the graph.
-        /// </summary>
-        [Obsolete]
-        [Browsable(false)]
-        public string ElementSelector
-        {
-            get { return ValueSelector; }
-            set { ValueSelector = value; }
-        }
-
         internal VisualizerController Controller { get; set; }
 
         internal class VisualizerController

--- a/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
@@ -1,0 +1,164 @@
+﻿using Bonsai.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that configures a visualizer to plot each element
+    /// of the sequence as a rolling graph.
+    /// </summary>
+    [DefaultProperty(nameof(ValueSelector))]
+    [TypeVisualizer(typeof(RollingGraphVisualizer))]
+    [Description("A visualizer that plots each element of the sequence as a rolling graph.")]
+    public class RollingGraphBuilder : SingleArgumentExpressionBuilder
+    {
+        /// <summary>
+        /// Gets or sets the name of the property that will be used as index for the graph.
+        /// </summary>
+        [Editor("Bonsai.Design.MemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The name of the property that will be used as index for the graph.")]
+        public string IndexSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the names of the properties that will be displayed in the graph.
+        /// </summary>
+        [Editor("Bonsai.Design.MultiMemberSelectorEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("The names of the properties that will be displayed in the graph.")]
+        public string ValueSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional symbol type to use for the line graph.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The optional symbol type to use for the line graph.")]
+        public SymbolType SymbolType { get; set; } = SymbolType.None;
+
+        /// <summary>
+        /// Gets or sets the width, in points, to be used for the line graph. Use a value of zero to hide the line.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("The width, in points, to be used for the line graph. Use a value of zero to hide the line.")]
+        public float LineWidth { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified,
+        /// all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.")]
+        public int? Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        public double? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        public double? Max { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether to serialize the element selector property.
+        /// </summary>
+        /// <returns>
+        /// This method always returns <see langword="false"/> as this is an obsolete property.
+        /// </returns>
+        [Obsolete]
+        public bool ShouldSerializeElementSelector() => false;
+
+        /// <summary>
+        /// Gets or sets the names of the properties that will be displayed in the graph.
+        /// </summary>
+        [Obsolete]
+        [Browsable(false)]
+        public string ElementSelector
+        {
+            get { return ValueSelector; }
+            set { ValueSelector = value; }
+        }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal int? Capacity;
+            internal double? Min;
+            internal double? Max;
+            internal Type IndexType;
+            internal string IndexLabel;
+            internal string[] ValueLabels;
+            internal SymbolType SymbolType;
+            internal float LineWidth;
+            internal Action<DateTime, object, IRollingGraphVisualizer> AddValues;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// line graph visualizer on the specified input argument.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.First();
+            var parameterType = source.Type.GetGenericArguments()[0];
+            var timeParameter = Expression.Parameter(typeof(DateTime));
+            var valueParameter = Expression.Parameter(typeof(object));
+            var viewParameter = Expression.Parameter(typeof(IRollingGraphVisualizer));
+            var elementVariable = Expression.Variable(parameterType);
+            Controller = new VisualizerController
+            {
+                Capacity = Capacity,
+                Min = Min,
+                Max = Max,
+                SymbolType = SymbolType,
+                LineWidth = LineWidth
+            };
+
+            var selectedIndex = GraphHelper.SelectIndexMember(timeParameter, elementVariable, IndexSelector, out Controller.IndexLabel);
+            Controller.IndexType = selectedIndex.Type;
+            if (selectedIndex.Type != typeof(double) && selectedIndex.Type != typeof(string))
+            {
+                selectedIndex = Expression.Convert(selectedIndex, typeof(double));
+            }
+
+            var selectedValues = GraphHelper.SelectDataValues(elementVariable, ValueSelector, out Controller.ValueLabels);
+            var showBody = Expression.Block(new[] { elementVariable },
+                Expression.Assign(elementVariable, Expression.Convert(valueParameter, parameterType)),
+                Expression.Call(viewParameter, nameof(IRollingGraphVisualizer.AddValues), null, selectedIndex, selectedValues));
+            Controller.AddValues = Expression.Lambda<Action<DateTime, object, IRollingGraphVisualizer>>(
+                showBody,
+                timeParameter,
+                valueParameter,
+                viewParameter)
+                .Compile();
+            return Expression.Call(typeof(RollingGraphBuilder), nameof(Process), new[] { parameterType }, source);
+        }
+
+        static IObservable<TSource> Process<TSource>(IObservable<TSource> source)
+        {
+            return source;
+        }
+    }
+
+    interface IRollingGraphVisualizer
+    {
+        void AddValues(string index, params double[] values);
+
+        void AddValues(double index, params double[] values);
+
+        void AddValues(double index, string tag, params double[] values);
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
@@ -47,6 +47,13 @@ namespace Bonsai.Gui.Visualizers
         public float LineWidth { get; set; } = 1;
 
         /// <summary>
+        /// Gets the optional settings for each line added to the graph.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies optional settings for each line added to the graph.")]
+        public Collection<CurveConfiguration> CurveSettings { get; } = new();
+
+        /// <summary>
         /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified,
         /// all data points will be displayed.
         /// </summary>
@@ -102,6 +109,7 @@ namespace Bonsai.Gui.Visualizers
             internal string[] ValueLabels;
             internal SymbolType SymbolType;
             internal float LineWidth;
+            internal CurveConfiguration[] CurveSettings;
             internal Action<DateTime, object, IRollingGraphVisualizer> AddValues;
         }
 
@@ -124,7 +132,8 @@ namespace Bonsai.Gui.Visualizers
                 Min = Min,
                 Max = Max,
                 SymbolType = SymbolType,
-                LineWidth = LineWidth
+                LineWidth = LineWidth,
+                CurveSettings = CurveSettings.ToArray()
             };
 
             var selectedIndex = GraphHelper.SelectIndexMember(timeParameter, elementVariable, IndexSelector, out Controller.IndexLabel);

--- a/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
@@ -62,19 +62,19 @@ namespace Bonsai.Gui.Visualizers
         public int? Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed lower limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed lower limit for the value axis.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed lower limit of the y-axis range.")]
+        [Description("Specifies the optional fixed lower limit for the value axis.")]
         public double? Min { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed upper limit for the y-axis range.
+        /// Gets or sets a value specifying a fixed upper limit for the value axis.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed upper limit of the y-axis range.")]
+        [Description("Specifies the optional fixed upper limit for the value axis.")]
         public double? Max { get; set; }
 
         internal VisualizerController Controller { get; set; }

--- a/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
@@ -20,7 +20,7 @@ namespace Bonsai.Gui.Visualizers
     {
         GraphPanelVisualizer visualizer;
         RollingGraphBuilder.VisualizerController controller;
-        IPointListEdit[] series;
+        BoundedPointPairList[] series;
 
         void IRollingGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
 
@@ -32,7 +32,7 @@ namespace Bonsai.Gui.Visualizers
         {
             for (int i = 0; i < series.Length; i++)
             {
-                series[i].Add(new PointPair(index, values[i], double.MaxValue, tag));
+                series[i].Add(index, values[i], index, tag);
             }
         }
 
@@ -48,10 +48,10 @@ namespace Bonsai.Gui.Visualizers
             var hasLabels = controller.ValueLabels != null;
             if (hasLabels)
             {
-                series = new IPointListEdit[controller.ValueLabels.Length];
+                series = new BoundedPointPairList[controller.ValueLabels.Length];
                 for (int i = 0; i < series.Length; i++)
                 {
-                    series[i] = new PointPairList();
+                    series[i] = new BoundedPointPairList();
                     var curveSettings = controller.CurveSettings.Length > 0
                         ? controller.CurveSettings[i % controller.CurveSettings.Length]
                         : null;

--- a/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
@@ -30,9 +30,19 @@ namespace Bonsai.Gui.Visualizers
 
         internal void AddValues(double index, string tag, params double[] values)
         {
-            for (int i = 0; i < series.Length; i++)
+            if (visualizer.BarSettings.Base <= BarBase.X2)
             {
-                series[i].Add(index, values[i], index, tag);
+                for (int i = 0; i < series.Length; i++)
+                {
+                    series[i].Add(index, values[i], index, tag);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < series.Length; i++)
+                {
+                    series[i].Add(values[i], index, index, tag);
+                }
             }
         }
 

--- a/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphOverlay.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Reactive;
+using Bonsai;
+using Bonsai.Design;
+using Bonsai.Gui.Visualizers;
+using Bonsai.Expressions;
+using ZedGraph;
+
+[assembly: TypeVisualizer(typeof(RollingGraphOverlay), Target = typeof(MashupSource<GraphPanelVisualizer, RollingGraphVisualizer>))]
+
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer used to overlay a sequence of values as a rolling graph.
+    /// </summary>
+    public class RollingGraphOverlay : BufferedVisualizer, IRollingGraphVisualizer
+    {
+        GraphPanelVisualizer visualizer;
+        RollingGraphBuilder.VisualizerController controller;
+        IPointListEdit[] series;
+
+        void IRollingGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
+
+        void IRollingGraphVisualizer.AddValues(double index, params double[] values) => AddValues(index, null, values);
+
+        void IRollingGraphVisualizer.AddValues(double index, string tag, params double[] values) => AddValues(index, null, values);
+
+        internal void AddValues(double index, string tag, params double[] values)
+        {
+            for (int i = 0; i < series.Length; i++)
+            {
+                series[i].Add(new PointPair(index, values[i], double.MaxValue, tag));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            visualizer = (GraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var rollingGraphBuilder = (RollingGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = rollingGraphBuilder.Controller;
+            visualizer.EnsureIndex(controller.IndexType);
+
+            var hasLabels = controller.ValueLabels != null;
+            if (hasLabels)
+            {
+                series = new IPointListEdit[controller.ValueLabels.Length];
+                for (int i = 0; i < series.Length; i++)
+                {
+                    series[i] = new PointPairList();
+                    var curveSettings = controller.CurveSettings.Length > 0
+                        ? controller.CurveSettings[i % controller.CurveSettings.Length]
+                        : null;
+                    var color = curveSettings?.Color.IsEmpty == false
+                        ? curveSettings.Color
+                        : visualizer.Control.GetNextColor();
+                    var curve = CreateSeries(curveSettings?.Label ?? controller.ValueLabels[i], series[i], color);
+                    visualizer.Control.GraphPane.CurveList.Add(curve);
+                }
+            }
+        }
+
+        private CurveItem CreateSeries(string label, IPointListEdit points, Color color)
+        {
+            var curve = new LineItem(label, points, color, controller.SymbolType, controller.LineWidth);
+            curve.Line.IsAntiAlias = true;
+            curve.Line.IsOptimizedDraw = true;
+            curve.Label.IsVisible = !string.IsNullOrEmpty(label);
+            curve.Symbol.Fill.Type = FillType.Solid;
+            curve.Symbol.IsAntiAlias = true;
+            return curve;
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
+            {
+                visualizer.Control.Invalidate();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(time, value, this);
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            visualizer = null;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphView.Designer.cs
@@ -1,0 +1,155 @@
+﻿namespace Bonsai.Gui.Visualizers
+{
+    partial class RollingGraphView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButton = new System.Windows.Forms.ToolStripButton();
+            this.graph = new Bonsai.Gui.Visualizers.LineGraph();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.capacityStatusLabel,
+            this.capacityValueLabel,
+            this.scaleStatusLabel,
+            this.minStatusLabel,
+            this.maxStatusLabel,
+            this.autoScaleButton});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip1";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // capacityStatusLabel
+            // 
+            this.capacityStatusLabel.Name = "capacityStatusLabel";
+            this.capacityStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.capacityStatusLabel.Text = "Capacity:";
+            // 
+            // capacityValueLabel
+            // 
+            this.capacityValueLabel.Name = "capacityValueLabel";
+            this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.capacityValueLabel.Text = "count";
+            // 
+            // scaleStatusLabel
+            // 
+            this.scaleStatusLabel.Name = "scaleStatusLabel";
+            this.scaleStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabel.Text = "Scale:";
+            // 
+            // minStatusLabel
+            // 
+            this.minStatusLabel.Name = "minStatusLabel";
+            this.minStatusLabel.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabel.Text = "min";
+            this.minStatusLabel.Visible = false;
+            // 
+            // maxStatusLabel
+            // 
+            this.maxStatusLabel.Name = "maxStatusLabel";
+            this.maxStatusLabel.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabel.Text = "Max";
+            this.maxStatusLabel.Visible = false;
+            // 
+            // autoScaleButton
+            // 
+            this.autoScaleButton.Checked = true;
+            this.autoScaleButton.CheckOnClick = true;
+            this.autoScaleButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButton.Name = "autoScaleButton";
+            this.autoScaleButton.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButton.Text = "auto";
+            this.autoScaleButton.CheckedChanged += new System.EventHandler(this.autoScaleButton_CheckedChanged);
+            // 
+            // graph
+            // 
+            this.graph.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.graph.Location = new System.Drawing.Point(0, 0);
+            this.graph.Name = "graph";
+            this.graph.ScrollGrace = 0D;
+            this.graph.ScrollMaxX = 0D;
+            this.graph.ScrollMaxY = 0D;
+            this.graph.ScrollMaxY2 = 0D;
+            this.graph.ScrollMinX = 0D;
+            this.graph.ScrollMinY = 0D;
+            this.graph.ScrollMinY2 = 0D;
+            this.graph.Size = new System.Drawing.Size(400, 218);
+            this.graph.TabIndex = 2;
+            this.graph.MouseMoveEvent += new ZedGraph.ZedGraphControl.ZedMouseEventHandler(this.graph_MouseMoveEvent);
+            this.graph.MouseClick += new System.Windows.Forms.MouseEventHandler(this.graph_MouseClick);
+            // 
+            // RollingGraphView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.graph);
+            this.Controls.Add(this.statusStrip);
+            this.Name = "RollingGraphView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripButton autoScaleButton;
+        private LineGraph graph;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphView.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphView.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Windows.Forms;
+using ZedGraph;
+using System.Globalization;
+
+namespace Bonsai.Gui.Visualizers
+{
+    partial class RollingGraphView : UserControl
+    {
+        readonly ToolStripEditableLabel minEditableLabel;
+        readonly ToolStripEditableLabel maxEditableLabel;
+        readonly ToolStripEditableLabel capacityEditableLabel;
+
+        public RollingGraphView()
+        {
+            InitializeComponent();
+            autoScaleButton.Checked = true;
+            capacityEditableLabel = new ToolStripEditableLabel(capacityValueLabel, OnCapacityEdit);
+            minEditableLabel = new ToolStripEditableLabel(minStatusLabel, OnMinEdit);
+            maxEditableLabel = new ToolStripEditableLabel(maxStatusLabel, OnMaxEdit);
+            Graph.GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
+            components.Add(capacityEditableLabel);
+            components.Add(minEditableLabel);
+            components.Add(maxEditableLabel);
+        }
+
+        protected StatusStrip StatusStrip
+        {
+            get { return statusStrip; }
+        }
+
+        public LineGraph Graph
+        {
+            get { return graph; }
+        }
+
+        public int NumSeries
+        {
+            get { return graph.NumSeries; }
+            set { graph.EnsureCapacity(value); }
+        }
+
+        public virtual int Capacity
+        {
+            get { return graph.Capacity; }
+            set { graph.Capacity = value; }
+        }
+
+        public bool CanEditCapacity
+        {
+            get { return capacityEditableLabel.Enabled; }
+            set { capacityEditableLabel.Enabled = value; }
+        }
+
+        public double Min
+        {
+            get { return graph.YMin; }
+            set { graph.YMin = value; }
+        }
+
+        public double Max
+        {
+            get { return graph.YMax; }
+            set { graph.YMax = value; }
+        }
+
+        public bool AutoScale
+        {
+            get { return autoScaleButton.Checked; }
+            set { autoScaleButton.Checked = value; }
+        }
+
+        public bool AutoScaleVisible
+        {
+            get { return autoScaleButton.Visible; }
+            set
+            {
+                autoScaleButton.Visible = value;
+                minEditableLabel.Enabled = value;
+                maxEditableLabel.Enabled = value;
+            }
+        }
+
+        public event EventHandler AutoScaleChanged
+        {
+            add { autoScaleButton.CheckedChanged += value; }
+            remove { autoScaleButton.CheckedChanged -= value; }
+        }
+
+        public event EventHandler AxisChanged;
+
+        protected virtual void OnAxisChanged(EventArgs e)
+        {
+            AxisChanged?.Invoke(this, e);
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            graph.EnsureCapacity(NumSeries);
+            base.OnLoad(e);
+        }
+
+        public virtual void AddValues(double index, params double[] values)
+        {
+            graph.AddValues(index, values);
+        }
+
+        private bool graph_MouseMoveEvent(ZedGraphControl sender, MouseEventArgs e)
+        {
+            var pane = graph.MasterPane.FindChartRect(e.Location);
+            if (pane != null)
+            {
+                pane.ReverseTransform(e.Location, out double x, out double y);
+                cursorStatusLabel.Text = string.Format("Cursor: ({0:F0}, {1:G5})", x, y);
+            }
+            return false;
+        }
+
+        private void graph_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                statusStrip.Visible = !statusStrip.Visible;
+            }
+        }
+
+        private void GraphPane_AxisChangeEvent(GraphPane pane)
+        {
+            var capacity = graph.Capacity;
+            var scale = pane.YAxis.Scale;
+            autoScaleButton.Checked = pane.YAxis.Scale.MaxAuto;
+            capacityValueLabel.Text = capacity.ToString(CultureInfo.InvariantCulture);
+            minStatusLabel.Text = scale.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabel.Text = scale.Max.ToString("G5", CultureInfo.InvariantCulture);
+            OnAxisChanged(EventArgs.Empty);
+        }
+
+        private void autoScaleButton_CheckedChanged(object sender, EventArgs e)
+        {
+            graph.AutoScaleY = autoScaleButton.Checked;
+            minStatusLabel.Visible = !autoScaleButton.Checked;
+            maxStatusLabel.Visible = !autoScaleButton.Checked;
+        }
+
+        private void OnCapacityEdit(string text)
+        {
+            if (int.TryParse(text, out int capacity))
+            {
+                Capacity = capacity;
+            }
+        }
+
+        private void OnMinEdit(string text)
+        {
+            if (double.TryParse(text, out double min))
+            {
+                Min = min;
+            }
+        }
+
+        private void OnMaxEdit(string text)
+        {
+            if (double.TryParse(text, out double max))
+            {
+                Max = max;
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphView.resx
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Reactive;
 using System.Windows.Forms;
-using ZedGraph;
 
 namespace Bonsai.Gui.Visualizers
 {
@@ -24,17 +23,17 @@ namespace Bonsai.Gui.Visualizers
         public int Capacity { get; set; }
 
         /// <summary>
-        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the lower limit for the value axis when using a fixed scale.
         /// </summary>
         public double Min { get; set; }
 
         /// <summary>
-        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// Gets or sets the upper limit for the value axis when using a fixed scale.
         /// </summary>
         public double Max { get; set; } = 1;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// Gets or sets a value indicating whether the value axis scale should be recalculated
         /// automatically as the graph updates.
         /// </summary>
         public bool AutoScale { get; set; } = true;

--- a/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
@@ -1,0 +1,162 @@
+﻿using Bonsai.Design;
+using Bonsai.Expressions;
+using System;
+using System.Windows.Forms;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer to display an object as a rolling graph.
+    /// </summary>
+    public class RollingGraphVisualizer : BufferedVisualizer, IRollingGraphVisualizer
+    {
+        static readonly TimeSpan TargetElapsedTime = TimeSpan.FromSeconds(1.0 / 30);
+        RollingGraphBuilder.VisualizerController controller;
+        DateTimeOffset updateTime;
+        RollingGraphView view;
+        bool labelLines;
+        bool reset;
+
+        /// <summary>
+        /// Gets or sets the maximum number of time points displayed at any one moment in the graph.
+        /// </summary>
+        public int Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper limit of the y-axis range when using a fixed scale.
+        /// </summary>
+        public double Max { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the y-axis range should be recalculated
+        /// automatically as the graph updates.
+        /// </summary>
+        public bool AutoScale { get; set; } = true;
+
+        void IRollingGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
+
+        void IRollingGraphVisualizer.AddValues(double index, params double[] values) => AddValues(index, null, values);
+
+        void IRollingGraphVisualizer.AddValues(double index, string tag, params double[] values) => AddValues(index, null, values);
+
+        internal void AddValues(double index, string tag, params double[] values)
+        {
+            if (view.Graph.NumSeries != values.Length || reset)
+            {
+                view.Graph.EnsureCapacity(
+                    values.Length,
+                    labelLines ? controller.ValueLabels : null,
+                    reset);
+                reset = false;
+            }
+            view.Graph.AddValues(index, tag, values);
+        }
+
+        /// <inheritdoc/>
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var lineChartBuilder = (RollingGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = lineChartBuilder.Controller;
+
+            view = new RollingGraphView();
+            view.Dock = DockStyle.Fill;
+            view.Graph.SymbolType = controller.SymbolType;
+            view.Graph.LineWidth = controller.LineWidth;
+            var indexAxis = view.Graph.GraphPane.XAxis;
+            var valueAxis = view.Graph.GraphPane.YAxis;
+            GraphHelper.FormatOrdinalAxis(indexAxis, controller.IndexType);
+            GraphHelper.SetAxisLabel(indexAxis, controller.IndexLabel);
+            if (controller.Min.HasValue || controller.Max.HasValue)
+            {
+                view.AutoScale = false;
+                view.AutoScaleVisible = false;
+                view.Min = controller.Min.GetValueOrDefault();
+                view.Max = controller.Max.GetValueOrDefault();
+            }
+            else
+            {
+                view.AutoScale = AutoScale;
+                if (!AutoScale)
+                {
+                    view.Min = Min;
+                    view.Max = Max;
+                }
+            }
+
+            if (controller.Capacity.HasValue)
+            {
+                view.Capacity = controller.Capacity.Value;
+                view.CanEditCapacity = false;
+            }
+            else
+            {
+                view.Capacity = Capacity;
+                view.CanEditCapacity = true;
+            }
+
+            var hasLabels = controller.ValueLabels != null;
+            var labelAxis = hasLabels && controller.ValueLabels.Length == 1;
+            if (labelAxis) GraphHelper.SetAxisLabel(valueAxis, controller.ValueLabels[0]);
+            labelLines = hasLabels && !labelAxis;
+            if (hasLabels)
+            {
+                view.Graph.EnsureCapacity(
+                    controller.ValueLabels.Length,
+                    labelLines ? controller.ValueLabels : null);
+            }
+
+            view.HandleDestroyed += delegate
+            {
+                Min = view.Min;
+                Max = view.Max;
+                AutoScale = view.AutoScale;
+                Capacity = view.Capacity;
+            };
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(view);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(time, value, this);
+            if ((time - updateTime) > TargetElapsedTime)
+            {
+                view.Graph.Invalidate();
+                updateTime = time;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void SequenceCompleted()
+        {
+            reset = true;
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            view.Dispose();
+            view = null;
+            controller = null;
+            reset = false;
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphVisualizer.cs
@@ -1,6 +1,8 @@
 ﻿using Bonsai.Design;
 using Bonsai.Expressions;
 using System;
+using System.Collections.Generic;
+using System.Reactive;
 using System.Windows.Forms;
 using ZedGraph;
 
@@ -11,9 +13,7 @@ namespace Bonsai.Gui.Visualizers
     /// </summary>
     public class RollingGraphVisualizer : BufferedVisualizer, IRollingGraphVisualizer
     {
-        static readonly TimeSpan TargetElapsedTime = TimeSpan.FromSeconds(1.0 / 30);
         RollingGraphBuilder.VisualizerController controller;
-        DateTimeOffset updateTime;
         RollingGraphView view;
         bool labelLines;
         bool reset;
@@ -137,10 +137,15 @@ namespace Bonsai.Gui.Visualizers
         protected override void Show(DateTime time, object value)
         {
             controller.AddValues(time, value, this);
-            if ((time - updateTime) > TargetElapsedTime)
+        }
+
+        /// <inheritdoc/>
+        protected override void ShowBuffer(IList<Timestamped<object>> values)
+        {
+            base.ShowBuffer(values);
+            if (values.Count > 0)
             {
                 view.Graph.Invalidate();
-                updateTime = time;
             }
         }
 

--- a/src/Bonsai.Gui.Visualizers/ThrowHelper.cs
+++ b/src/Bonsai.Gui.Visualizers/ThrowHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Bonsai.Gui.Visualizers
+{
+    static class ThrowHelper
+    {
+        public static void ThrowArgumentOutOfRange(string paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName);
+        }
+
+        public static void ThrowArgumentNull(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        public static void ThrowIfNotEquals<T>(T left, T right, string message)
+        {
+            if (!EqualityComparer<T>.Default.Equals(left, right))
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/ToolStripEditableLabel.cs
+++ b/src/Bonsai.Gui.Visualizers/ToolStripEditableLabel.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace Bonsai.Gui.Visualizers
+{
+    class ToolStripEditableLabel : IComponent
+    {
+        readonly ToolStripTextBox textBox;
+        readonly ToolStripStatusLabel valueLabel;
+        readonly Action<string> onEdit;
+        bool disposed;
+
+        public ToolStripEditableLabel(ToolStripStatusLabel statusLabel, Action<string> onLabelEdit)
+        {
+            if (statusLabel is null)
+            {
+                throw new ArgumentNullException(nameof(statusLabel));
+            }
+
+            onEdit = onLabelEdit;
+            valueLabel = statusLabel;
+            textBox = new ToolStripTextBox();
+            textBox.LostFocus += textBox_LostFocus;
+            textBox.KeyDown += textBox_KeyDown;
+            valueLabel.Click += valueLabel_Click;
+        }
+
+        public bool Enabled { get; set; } = true;
+
+        public ISite Site { get; set; }
+
+        public event EventHandler Disposed;
+
+        private void textBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Return)
+            {
+                e.SuppressKeyPress = true;
+                if (textBox.Owner is StatusStrip statusStrip)
+                {
+                    statusStrip.Select();
+                }
+            }
+        }
+
+        private void textBox_LostFocus(object sender, EventArgs e)
+        {
+            if (textBox.Text != valueLabel.Text && onEdit != null)
+            {
+                onEdit(textBox.Text);
+            }
+
+            if (textBox.Owner is StatusStrip statusStrip)
+            {
+                var labelIndex = statusStrip.Items.IndexOf(textBox);
+                statusStrip.SuspendLayout();
+                statusStrip.Items.Remove(textBox);
+                statusStrip.Items.Insert(labelIndex, valueLabel);
+                statusStrip.ResumeLayout();
+            }
+        }
+
+        private void valueLabel_Click(object sender, EventArgs e)
+        {
+            if (Enabled && valueLabel.Owner is StatusStrip statusStrip)
+            {
+                var labelIndex = statusStrip.Items.IndexOf(valueLabel);
+                statusStrip.SuspendLayout();
+                statusStrip.Items.Remove(valueLabel);
+                statusStrip.Items.Insert(labelIndex, textBox);
+                textBox.Size = valueLabel.Size;
+                textBox.Text = valueLabel.Text;
+                statusStrip.ResumeLayout();
+                textBox.Focus();
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    textBox.Dispose();
+                    Disposed?.Invoke(this, EventArgs.Empty);
+                }
+
+                disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for dynamic composition of multiple time-series plots via the new `GraphPanel` operator. This graph container also allows for setting a cap on number of points per time-series, and specifying a span in the base axis which is used to discard data in a moving or rolling fashion.

The main constraints in this first implementation is that each composed plot needs to share the same base axis type. The base axis currently can be either a linear range, a date range or a discrete set of values. It is possible to use either X or Y axes as the base axis as long as all the composed bar plots overlaid onto the panel share the same base.