### PR TITLE
Support mashup of both rolling and 2D graph panels

### DIFF
--- a/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
@@ -8,7 +8,7 @@ using Bonsai.Gui.Visualizers;
 using Bonsai.Expressions;
 using ZedGraph;
 
-[assembly: TypeVisualizer(typeof(BarGraphOverlay), Target = typeof(MashupSource<GraphPanelVisualizer, BarGraphVisualizer>))]
+[assembly: TypeVisualizer(typeof(BarGraphOverlay), Target = typeof(MashupSource<RollingGraphPanelVisualizer, BarGraphVisualizer>))]
 
 
 namespace Bonsai.Gui.Visualizers
@@ -18,7 +18,7 @@ namespace Bonsai.Gui.Visualizers
     /// </summary>
     public class BarGraphOverlay : BufferedVisualizer, IBarGraphVisualizer
     {
-        GraphPanelVisualizer visualizer;
+        RollingGraphPanelVisualizer visualizer;
         BarGraphBuilder.VisualizerController controller;
         BoundedPointPairList[] series;
 
@@ -83,7 +83,7 @@ namespace Bonsai.Gui.Visualizers
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            visualizer = (GraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
+            visualizer = (RollingGraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
             var barGraphBuilder = (BarGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
             controller = barGraphBuilder.Controller;

--- a/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphOverlay.cs
@@ -141,7 +141,7 @@ namespace Bonsai.Gui.Visualizers
         /// <inheritdoc/>
         protected override void Show(DateTime time, object value)
         {
-            controller.AddValues(value, this);
+            controller.AddValues(time, value, this);
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/BarGraphVisualizer.cs
@@ -149,12 +149,6 @@ namespace Bonsai.Gui.Visualizers
         }
 
         /// <inheritdoc/>
-        public override void Show(object value)
-        {
-            controller.AddValues(value, this);
-        }
-
-        /// <inheritdoc/>
         protected override void ShowBuffer(IList<Timestamped<object>> values)
         {
             base.ShowBuffer(values);
@@ -162,6 +156,18 @@ namespace Bonsai.Gui.Visualizers
             {
                 view.Graph.Invalidate();
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(time, value, this);
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
+++ b/src/Bonsai.Gui.Visualizers/Bonsai.Gui.Visualizers.csproj.user
@@ -14,16 +14,16 @@
     <Compile Update="GraphControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="RollingGraphPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="GraphPanel.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Update="GraphPanel2D.cs">
+    <Compile Update="RollingGraphPanelView.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="GraphPanelView.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="GraphPanelView2D.cs">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="LineGraph.cs">

--- a/src/Bonsai.Gui.Visualizers/GraphHelper.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphHelper.cs
@@ -150,7 +150,7 @@ namespace Bonsai.Gui.Visualizers
             if (memberNames.Length == 1)
             {
                 var memberName = memberNames[0];
-                valueLabels = memberName != ExpressionHelper.ImplicitParameterName ? new[] { memberName } : null;
+                valueLabels = new[] { memberName };
                 var member = ExpressionHelper.MemberAccess(expression, memberNames[0]);
                 if (member.Type.IsArray)
                 {

--- a/src/Bonsai.Gui.Visualizers/GraphPanel.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanel.cs
@@ -4,56 +4,87 @@ namespace Bonsai.Gui.Visualizers
 {
     internal class GraphPanel : BoundedGraphPanel
     {
-        bool autoScale;
+        bool autoScaleX;
+        bool autoScaleY;
 
         public GraphPanel()
         {
-            autoScale = true;
+            autoScaleX = true;
+            autoScaleY = true;
         }
 
-        public Axis ScaleAxis => GraphPane.BarSettings.Base switch
+        public double XMin
         {
-            BarBase.Y => GraphPane.XAxis,
-            BarBase.Y2 => GraphPane.X2Axis,
-            BarBase.X2 => GraphPane.Y2Axis,
-            _ => GraphPane.YAxis
-        };
-
-        public double Min
-        {
-            get { return ScaleAxis.Scale.Min; }
+            get { return GraphPane.XAxis.Scale.Min; }
             set
             {
-                ScaleAxis.Scale.Min = value;
+                GraphPane.XAxis.Scale.Min = value;
                 GraphPane.AxisChange();
                 Invalidate();
             }
         }
 
-        public double Max
+        public double XMax
         {
-            get { return ScaleAxis.Scale.Max; }
+            get { return GraphPane.XAxis.Scale.Max; }
             set
             {
-                ScaleAxis.Scale.Max = value;
+                GraphPane.XAxis.Scale.Max = value;
                 GraphPane.AxisChange();
                 Invalidate();
             }
         }
 
-        public bool AutoScale
+        public double YMin
         {
-            get { return autoScale; }
+            get { return GraphPane.YAxis.Scale.Min; }
             set
             {
-                var changed = autoScale != value;
-                autoScale = value;
+                GraphPane.YAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double YMax
+        {
+            get { return GraphPane.YAxis.Scale.Max; }
+            set
+            {
+                GraphPane.YAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public bool AutoScaleX
+        {
+            get { return autoScaleX; }
+            set
+            {
+                var changed = autoScaleX != value;
+                autoScaleX = value;
                 if (changed)
                 {
-                    var baseAxis = ScaleAxis;
-                    baseAxis.Scale.MaxAuto = autoScale;
-                    baseAxis.Scale.MinAuto = autoScale;
-                    if (autoScale) Invalidate();
+                    GraphPane.XAxis.Scale.MaxAuto = autoScaleX;
+                    GraphPane.XAxis.Scale.MinAuto = autoScaleX;
+                    if (autoScaleX) Invalidate();
+                }
+            }
+        }
+
+        public bool AutoScaleY
+        {
+            get { return autoScaleY; }
+            set
+            {
+                var changed = autoScaleY != value;
+                autoScaleY = value;
+                if (changed)
+                {
+                    GraphPane.YAxis.Scale.MaxAuto = autoScaleY;
+                    GraphPane.YAxis.Scale.MinAuto = autoScaleY;
+                    if (autoScaleY) Invalidate();
                 }
             }
         }

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reactive.Linq;
 using System.Reactive;
-using Bonsai.Expressions;
 using ZedGraph;
 
 namespace Bonsai.Gui.Visualizers
@@ -14,15 +13,8 @@ namespace Bonsai.Gui.Visualizers
     /// </summary>
     [TypeVisualizer(typeof(GraphPanelVisualizer))]
     [Description("Specifies a mashup graph panel that can be used to combine multiple plots sharing the same axes.")]
-    public class GraphPanelBuilder : ZeroArgumentExpressionBuilder, INamedElement
+    public class GraphPanelBuilder : GraphPanelBuilderBase
     {
-        /// <summary>
-        /// Gets or sets the name of the visualizer window.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Design))]
-        [Description("The name of the visualizer window.")]
-        public string Name { get; set; }
-
         /// <summary>
         /// Gets or sets a value specifying the axis on which the bars in the graph will be displayed.
         /// </summary>
@@ -37,36 +29,6 @@ namespace Bonsai.Gui.Visualizers
         [Category(nameof(CategoryAttribute.Appearance))]
         [Description("Specifies how the different bars in the graph will be visually arranged.")]
         public BarType BarType { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether the scale values are reversed on the X-axis.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies whether the scale values are reversed on the X-axis.")]
-        public bool ReverseX { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying whether the scale values are reversed on the Y-axis.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies whether the scale values are reversed on the Y-axis.")]
-        public bool ReverseY { get; set; }
-
-        /// <summary>
-        /// Gets or sets the optional maximum span of data displayed at any one moment in the graph.
-        /// If no span is specified, all data points will be displayed.
-        /// </summary>
-        [Category("Range")]
-        [Description("The optional maximum span of data displayed at any one moment in the graph. " +
-                     "If no span is specified, all data points will be displayed.")]
-        public double? Span { get; set; }
-
-        /// <summary>
-        /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.
-        /// </summary>
-        [Category("Range")]
-        [Description("The optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.")]
-        public int? Capacity { get; set; }
 
         /// <summary>
         /// Gets or sets a value specifying a fixed lower limit for the axis range.

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilder.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 using System.Reactive.Linq;
 using System.Reactive;
-using ZedGraph;
 
 namespace Bonsai.Gui.Visualizers
 {
@@ -16,46 +15,47 @@ namespace Bonsai.Gui.Visualizers
     public class GraphPanelBuilder : GraphPanelBuilderBase
     {
         /// <summary>
-        /// Gets or sets a value specifying the axis on which the bars in the graph will be displayed.
-        /// </summary>
-        [TypeConverter(typeof(BaseAxisConverter))]
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies the axis on which the bars in the graph will be displayed.")]
-        public BarBase BaseAxis { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying how the different bars in the graph will be visually arranged.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Appearance))]
-        [Description("Specifies how the different bars in the graph will be visually arranged.")]
-        public BarType BarType { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value specifying a fixed lower limit for the axis range.
+        /// Gets or sets a value specifying a fixed lower limit for the X-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed lower limit of the axis range.")]
-        public double? Min { get; set; }
+        [Description("Specifies the optional fixed lower limit of the X-axis range.")]
+        public double? XMin { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying a fixed upper limit for the axis range.
+        /// Gets or sets a value specifying a fixed upper limit for the X-axis range.
         /// If no fixed range is specified, the graph limits can be edited online.
         /// </summary>
         [Category("Range")]
-        [Description("Specifies the optional fixed upper limit of the axis range.")]
-        public double? Max { get; set; }
+        [Description("Specifies the optional fixed upper limit of the X-axis range.")]
+        public double? XMax { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the Y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the Y-axis range.")]
+        public double? YMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the Y-axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the Y-axis range.")]
+        public double? YMax { get; set; }
 
         internal VisualizerController Controller { get; set; }
 
         internal class VisualizerController
         {
-            internal BarBase BaseAxis;
-            internal BarType BarType;
             internal double? Span;
             internal int? Capacity;
-            internal double? Min;
-            internal double? Max;
+            internal double? XMin;
+            internal double? XMax;
+            internal double? YMin;
+            internal double? YMax;
             internal bool ReverseX;
             internal bool ReverseY;
         }
@@ -69,12 +69,12 @@ namespace Bonsai.Gui.Visualizers
         {
             Controller = new VisualizerController
             {
-                BaseAxis = BaseAxis,
-                BarType = BarType,
                 Span = Span,
                 Capacity = Capacity,
-                Min = Min,
-                Max = Max,
+                XMin = XMin,
+                XMax = XMax,
+                YMin = YMin,
+                YMax = YMax,
                 ReverseX = ReverseX,
                 ReverseY = ReverseY
             };

--- a/src/Bonsai.Gui.Visualizers/GraphPanelBuilderBase.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelBuilderBase.cs
@@ -1,0 +1,48 @@
+﻿using System.ComponentModel;
+using Bonsai.Expressions;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides an abstract base class with common mashup graph panel functionality.
+    /// </summary>
+    public abstract class GraphPanelBuilderBase : ZeroArgumentExpressionBuilder, INamedElement
+    {
+        /// <summary>
+        /// Gets or sets the name of the visualizer window.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Design))]
+        [Description("The name of the visualizer window.")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the scale values are reversed on the X-axis.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies whether the scale values are reversed on the X-axis.")]
+        public bool ReverseX { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying whether the scale values are reversed on the Y-axis.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies whether the scale values are reversed on the Y-axis.")]
+        public bool ReverseY { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional maximum span of data displayed at any one moment in the graph.
+        /// If no span is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional maximum span of data displayed at any one moment in the graph. " +
+                     "If no span is specified, all data points will be displayed.")]
+        public double? Span { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.
+        /// </summary>
+        [Category("Range")]
+        [Description("The optional capacity used for rolling line graphs. If no capacity is specified, all data points will be displayed.")]
+        public int? Capacity { get; set; }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/GraphPanelView.Designer.cs
@@ -35,10 +35,14 @@
             this.spanValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.scaleStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.minStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.maxStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.autoScaleButton = new System.Windows.Forms.ToolStripButton();
+            this.scaleStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelX = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabelY = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButtonX = new System.Windows.Forms.ToolStripButton();
+            this.autoScaleButtonY = new System.Windows.Forms.ToolStripButton();
             this.statusStrip.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -50,10 +54,14 @@
             this.spanValueLabel,
             this.capacityStatusLabel,
             this.capacityValueLabel,
-            this.scaleStatusLabel,
-            this.minStatusLabel,
-            this.maxStatusLabel,
-            this.autoScaleButton});
+            this.scaleStatusLabelX,
+            this.minStatusLabelX,
+            this.maxStatusLabelX,
+            this.autoScaleButtonX,
+            this.scaleStatusLabelY,
+            this.minStatusLabelY,
+            this.maxStatusLabelY,
+            this.autoScaleButtonY});
             this.statusStrip.Location = new System.Drawing.Point(0, 218);
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.Size = new System.Drawing.Size(400, 22);
@@ -91,44 +99,76 @@
             this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
             this.capacityValueLabel.Text = "count";
             // 
-            // scaleStatusLabel
+            // scaleStatusLabelX
             // 
-            this.scaleStatusLabel.Name = "scaleStatusLabel";
-            this.scaleStatusLabel.Size = new System.Drawing.Size(47, 17);
-            this.scaleStatusLabel.Text = "Scale:";
+            this.scaleStatusLabelX.Name = "statusLabelX";
+            this.scaleStatusLabelX.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelX.Text = "X:";
             // 
-            // minStatusLabel
+            // minStatusLabelX
             // 
-            this.minStatusLabel.Name = "minStatusLabel";
-            this.minStatusLabel.Size = new System.Drawing.Size(13, 17);
-            this.minStatusLabel.Text = "min";
-            this.minStatusLabel.Visible = false;
+            this.minStatusLabelX.Name = "minStatusLabelX";
+            this.minStatusLabelX.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelX.Text = "min";
+            this.minStatusLabelX.Visible = false;
             // 
-            // maxStatusLabel
+            // maxStatusLabelX
             // 
-            this.maxStatusLabel.Name = "maxStatusLabel";
-            this.maxStatusLabel.Size = new System.Drawing.Size(14, 17);
-            this.maxStatusLabel.Text = "Max";
-            this.maxStatusLabel.Visible = false;
+            this.maxStatusLabelX.Name = "maxStatusLabelX";
+            this.maxStatusLabelX.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelX.Text = "Max";
+            this.maxStatusLabelX.Visible = false;
             // 
-            // autoScaleButton
+            // autoScaleButtonX
             // 
-            this.autoScaleButton.Checked = true;
-            this.autoScaleButton.CheckOnClick = true;
-            this.autoScaleButton.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.autoScaleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.autoScaleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.autoScaleButton.Name = "autoScaleButton";
-            this.autoScaleButton.Size = new System.Drawing.Size(35, 20);
-            this.autoScaleButton.Text = "auto";
-            this.autoScaleButton.CheckedChanged += new System.EventHandler(this.autoScaleButton_CheckedChanged);
+            this.autoScaleButtonX.Checked = true;
+            this.autoScaleButtonX.CheckOnClick = true;
+            this.autoScaleButtonX.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonX.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonX.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonX.Name = "autoScaleButtonX";
+            this.autoScaleButtonX.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonX.Text = "auto";
+            this.autoScaleButtonX.CheckedChanged += new System.EventHandler(this.autoScaleButtonX_CheckedChanged);
             // 
-            // GraphPanelView
+            // scaleStatusLabelY
+            // 
+            this.scaleStatusLabelY.Name = "statusLabelY";
+            this.scaleStatusLabelY.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabelY.Text = "Y:";
+            // 
+            // minStatusLabelY
+            // 
+            this.minStatusLabelY.Name = "minStatusLabelY";
+            this.minStatusLabelY.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabelY.Text = "min";
+            this.minStatusLabelY.Visible = false;
+            // 
+            // maxStatusLabelY
+            // 
+            this.maxStatusLabelY.Name = "maxStatusLabelY";
+            this.maxStatusLabelY.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabelY.Text = "Max";
+            this.maxStatusLabelY.Visible = false;
+            // 
+            // autoScaleButtonY
+            // 
+            this.autoScaleButtonY.Checked = true;
+            this.autoScaleButtonY.CheckOnClick = true;
+            this.autoScaleButtonY.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButtonY.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButtonY.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButtonY.Name = "autoScaleButtonY";
+            this.autoScaleButtonY.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButtonY.Text = "auto";
+            this.autoScaleButtonY.CheckedChanged += new System.EventHandler(this.autoScaleButtonY_CheckedChanged);
+            // 
+            // GraphPanelView2D
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.statusStrip);
-            this.Name = "GraphPanelView";
+            this.Name = "GraphPanelView2D";
             this.Size = new System.Drawing.Size(400, 240);
             this.statusStrip.ResumeLayout(false);
             this.statusStrip.PerformLayout();
@@ -140,11 +180,15 @@
         #endregion
 
         private System.Windows.Forms.StatusStrip statusStrip;
-        private System.Windows.Forms.ToolStripButton autoScaleButton;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonX;
+        private System.Windows.Forms.ToolStripButton autoScaleButtonY;
         private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
-        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabel;
-        private System.Windows.Forms.ToolStripStatusLabel minStatusLabel;
-        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelX;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabelY;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabelY;
         private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
         private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
         private System.Windows.Forms.ToolStripStatusLabel spanStatusLabel;

--- a/src/Bonsai.Gui.Visualizers/LineGraphOverlay.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphOverlay.cs
@@ -8,51 +8,35 @@ using Bonsai.Gui.Visualizers;
 using Bonsai.Expressions;
 using ZedGraph;
 
-[assembly: TypeVisualizer(typeof(RollingGraphOverlay), Target = typeof(MashupSource<RollingGraphPanelVisualizer, RollingGraphVisualizer>))]
+[assembly: TypeVisualizer(typeof(LineGraphOverlay), Target = typeof(MashupSource<GraphPanelVisualizer, LineGraphVisualizer>))]
 
 
 namespace Bonsai.Gui.Visualizers
 {
     /// <summary>
-    /// Provides a type visualizer used to overlay a sequence of values as a rolling graph.
+    /// Provides a type visualizer used to overlay a sequence of points as a line graph.
     /// </summary>
-    public class RollingGraphOverlay : BufferedVisualizer, IRollingGraphVisualizer
+    public class LineGraphOverlay : BufferedVisualizer, ILineGraphVisualizer
     {
-        RollingGraphPanelVisualizer visualizer;
-        RollingGraphBuilder.VisualizerController controller;
+        GraphPanelVisualizer visualizer;
+        LineGraphBuilder.VisualizerController controller;
         BoundedPointPairList[] series;
 
-        void IRollingGraphVisualizer.AddValues(string index, params double[] values) => AddValues(0, index, values);
-
-        void IRollingGraphVisualizer.AddValues(double index, params double[] values) => AddValues(index, null, values);
-
-        void IRollingGraphVisualizer.AddValues(double index, string tag, params double[] values) => AddValues(index, null, values);
-
-        internal void AddValues(double index, string tag, params double[] values)
+        void ILineGraphVisualizer.AddValues(double index, params PointPair[] values)
         {
-            if (visualizer.BarSettings.Base <= BarBase.X2)
+            for (int i = 0; i < series.Length; i++)
             {
-                for (int i = 0; i < series.Length; i++)
-                {
-                    series[i].Add(index, values[i], index, tag);
-                }
-            }
-            else
-            {
-                for (int i = 0; i < series.Length; i++)
-                {
-                    series[i].Add(values[i], index, index, tag);
-                }
+                series[i].Add(values[i].X, values[i].Y, index, values[i].Tag);
             }
         }
 
         /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
-            visualizer = (RollingGraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
+            visualizer = (GraphPanelVisualizer)provider.GetService(typeof(MashupVisualizer));
             var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
-            var rollingGraphBuilder = (RollingGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
-            controller = rollingGraphBuilder.Controller;
+            var lineGraphBuilder = (LineGraphBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            controller = lineGraphBuilder.Controller;
             visualizer.EnsureIndex(controller.IndexType);
 
             var hasLabels = controller.ValueLabels != null;

--- a/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/LineGraphVisualizer.cs
@@ -11,7 +11,7 @@ namespace Bonsai.Gui.Visualizers
     /// <summary>
     /// Provides a type visualizer to display an object as a line graph.
     /// </summary>
-    public class LineGraphVisualizer : BufferedVisualizer
+    public class LineGraphVisualizer : BufferedVisualizer, ILineGraphVisualizer
     {
         LineGraphBuilder.VisualizerController controller;
         LineGraphView view;
@@ -55,7 +55,7 @@ namespace Bonsai.Gui.Visualizers
         /// </summary>
         public bool AutoScaleY { get; set; } = true;
 
-        internal void AddValues(PointPair[] values)
+        void ILineGraphVisualizer.AddValues(double index, params PointPair[] values)
         {
             if (view.Graph.NumSeries != values.Length || reset)
             {
@@ -65,7 +65,7 @@ namespace Bonsai.Gui.Visualizers
                     reset);
                 reset = false;
             }
-            view.Graph.AddValues(values);
+            view.Graph.AddValues(index, values);
         }
 
         /// <inheritdoc/>
@@ -158,12 +158,6 @@ namespace Bonsai.Gui.Visualizers
         }
 
         /// <inheritdoc/>
-        public override void Show(object value)
-        {
-            controller.AddValues(value, this);
-        }
-
-        /// <inheritdoc/>
         protected override void ShowBuffer(IList<Timestamped<object>> values)
         {
             base.ShowBuffer(values);
@@ -171,6 +165,18 @@ namespace Bonsai.Gui.Visualizers
             {
                 view.Graph.Invalidate();
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Show(object value)
+        {
+            Show(DateTime.Now, value);
+        }
+
+        /// <inheritdoc/>
+        protected override void Show(DateTime time, object value)
+        {
+            controller.AddValues(time, value, this);
         }
 
         /// <inheritdoc/>

--- a/src/Bonsai.Gui.Visualizers/RollingGraph.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraph.cs
@@ -176,11 +176,11 @@ namespace Bonsai.Gui.Visualizers
             }
         }
 
-        public void AddValues(params PointPair[] values)
+        public void AddValues(double index, params PointPair[] values)
         {
             for (int i = 0; i < series.Length; i++)
             {
-                series[i].Add(values[i]);
+                series[i].Add(values[i].X, values[i].Y, index, values[i].Tag);
             }
         }
 

--- a/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphBuilder.cs
@@ -124,11 +124,11 @@ namespace Bonsai.Gui.Visualizers
             }
 
             var selectedValues = GraphHelper.SelectDataValues(elementVariable, ValueSelector, out Controller.ValueLabels);
-            var showBody = Expression.Block(new[] { elementVariable },
+            var addValuesBody = Expression.Block(new[] { elementVariable },
                 Expression.Assign(elementVariable, Expression.Convert(valueParameter, parameterType)),
                 Expression.Call(viewParameter, nameof(IRollingGraphVisualizer.AddValues), null, selectedIndex, selectedValues));
             Controller.AddValues = Expression.Lambda<Action<DateTime, object, IRollingGraphVisualizer>>(
-                showBody,
+                addValuesBody,
                 timeParameter,
                 valueParameter,
                 viewParameter)

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanel.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanel.cs
@@ -1,0 +1,61 @@
+﻿using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    internal class RollingGraphPanel : BoundedGraphPanel
+    {
+        bool autoScale;
+
+        public RollingGraphPanel()
+        {
+            autoScale = true;
+        }
+
+        public Axis ScaleAxis => GraphPane.BarSettings.Base switch
+        {
+            BarBase.Y => GraphPane.XAxis,
+            BarBase.Y2 => GraphPane.X2Axis,
+            BarBase.X2 => GraphPane.Y2Axis,
+            _ => GraphPane.YAxis
+        };
+
+        public double Min
+        {
+            get { return ScaleAxis.Scale.Min; }
+            set
+            {
+                ScaleAxis.Scale.Min = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public double Max
+        {
+            get { return ScaleAxis.Scale.Max; }
+            set
+            {
+                ScaleAxis.Scale.Max = value;
+                GraphPane.AxisChange();
+                Invalidate();
+            }
+        }
+
+        public bool AutoScale
+        {
+            get { return autoScale; }
+            set
+            {
+                var changed = autoScale != value;
+                autoScale = value;
+                if (changed)
+                {
+                    var baseAxis = ScaleAxis;
+                    baseAxis.Scale.MaxAuto = autoScale;
+                    baseAxis.Scale.MinAuto = autoScale;
+                    if (autoScale) Invalidate();
+                }
+            }
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanelBuilder.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanelBuilder.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Reactive;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Represents an operator that specifies a mashup graph panel that can be used
+    /// to combine multiple graphs displaying data over a shared axis.
+    /// </summary>
+    [TypeVisualizer(typeof(RollingGraphPanelVisualizer))]
+    [Description("Specifies a mashup graph panel that can be used to combine multiple graphs displaying data over a shared axis.")]
+    public class RollingGraphPanelBuilder : GraphPanelBuilderBase
+    {
+        /// <summary>
+        /// Gets or sets a value specifying the axis on which the bars in the graph will be displayed.
+        /// </summary>
+        [TypeConverter(typeof(BaseAxisConverter))]
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies the axis on which the bars in the graph will be displayed.")]
+        public BarBase BaseAxis { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying how the different bars in the graph will be visually arranged.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Appearance))]
+        [Description("Specifies how the different bars in the graph will be visually arranged.")]
+        public BarType BarType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed lower limit for the axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed lower limit of the axis range.")]
+        public double? Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value specifying a fixed upper limit for the axis range.
+        /// If no fixed range is specified, the graph limits can be edited online.
+        /// </summary>
+        [Category("Range")]
+        [Description("Specifies the optional fixed upper limit of the axis range.")]
+        public double? Max { get; set; }
+
+        internal VisualizerController Controller { get; set; }
+
+        internal class VisualizerController
+        {
+            internal BarBase BaseAxis;
+            internal BarType BarType;
+            internal double? Span;
+            internal int? Capacity;
+            internal double? Min;
+            internal double? Max;
+            internal bool ReverseX;
+            internal bool ReverseY;
+        }
+
+        /// <summary>
+        /// Builds the expression tree for configuring and calling the
+        /// graph panel visualizer.
+        /// </summary>
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            Controller = new VisualizerController
+            {
+                BaseAxis = BaseAxis,
+                BarType = BarType,
+                Span = Span,
+                Capacity = Capacity,
+                Min = Min,
+                Max = Max,
+                ReverseX = ReverseX,
+                ReverseY = ReverseY
+            };
+            return Expression.Call(typeof(Observable), nameof(Observable.Never), new[] { typeof(Unit) });
+        }
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.Designer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.Designer.cs
@@ -1,0 +1,153 @@
+﻿namespace Bonsai.Gui.Visualizers
+{
+    partial class RollingGraphPanelView
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.cursorStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.spanStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.spanValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.capacityValueLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.scaleStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.minStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.maxStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.autoScaleButton = new System.Windows.Forms.ToolStripButton();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // statusStrip
+            // 
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cursorStatusLabel,
+            this.spanStatusLabel,
+            this.spanValueLabel,
+            this.capacityStatusLabel,
+            this.capacityValueLabel,
+            this.scaleStatusLabel,
+            this.minStatusLabel,
+            this.maxStatusLabel,
+            this.autoScaleButton});
+            this.statusStrip.Location = new System.Drawing.Point(0, 218);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(400, 22);
+            this.statusStrip.TabIndex = 1;
+            this.statusStrip.Text = "statusStrip1";
+            this.statusStrip.Visible = false;
+            // 
+            // cursorStatusLabel
+            // 
+            this.cursorStatusLabel.Name = "cursorStatusLabel";
+            this.cursorStatusLabel.Size = new System.Drawing.Size(45, 17);
+            this.cursorStatusLabel.Text = "Cursor:";
+            // 
+            // spanStatusLabel
+            // 
+            this.spanStatusLabel.Name = "spanStatusLabel";
+            this.spanStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.spanStatusLabel.Text = "Span:";
+            // 
+            // spanValueLabel
+            // 
+            this.spanValueLabel.Name = "spanValueLabel";
+            this.spanValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.spanValueLabel.Text = "value";
+            // 
+            // capacityStatusLabel
+            // 
+            this.capacityStatusLabel.Name = "capacityStatusLabel";
+            this.capacityStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.capacityStatusLabel.Text = "Capacity:";
+            // 
+            // capacityValueLabel
+            // 
+            this.capacityValueLabel.Name = "capacityValueLabel";
+            this.capacityValueLabel.Size = new System.Drawing.Size(12, 17);
+            this.capacityValueLabel.Text = "count";
+            // 
+            // scaleStatusLabel
+            // 
+            this.scaleStatusLabel.Name = "scaleStatusLabel";
+            this.scaleStatusLabel.Size = new System.Drawing.Size(47, 17);
+            this.scaleStatusLabel.Text = "Scale:";
+            // 
+            // minStatusLabel
+            // 
+            this.minStatusLabel.Name = "minStatusLabel";
+            this.minStatusLabel.Size = new System.Drawing.Size(13, 17);
+            this.minStatusLabel.Text = "min";
+            this.minStatusLabel.Visible = false;
+            // 
+            // maxStatusLabel
+            // 
+            this.maxStatusLabel.Name = "maxStatusLabel";
+            this.maxStatusLabel.Size = new System.Drawing.Size(14, 17);
+            this.maxStatusLabel.Text = "Max";
+            this.maxStatusLabel.Visible = false;
+            // 
+            // autoScaleButton
+            // 
+            this.autoScaleButton.Checked = true;
+            this.autoScaleButton.CheckOnClick = true;
+            this.autoScaleButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.autoScaleButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.autoScaleButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.autoScaleButton.Name = "autoScaleButton";
+            this.autoScaleButton.Size = new System.Drawing.Size(35, 20);
+            this.autoScaleButton.Text = "auto";
+            this.autoScaleButton.CheckedChanged += new System.EventHandler(this.autoScaleButton_CheckedChanged);
+            // 
+            // GraphPanelView
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.statusStrip);
+            this.Name = "GraphPanelView";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripButton autoScaleButton;
+        private System.Windows.Forms.ToolStripStatusLabel cursorStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel scaleStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel minStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel maxStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel capacityValueLabel;
+        private System.Windows.Forms.ToolStripStatusLabel spanStatusLabel;
+        private System.Windows.Forms.ToolStripStatusLabel spanValueLabel;
+    }
+}

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.cs
@@ -5,35 +5,28 @@ using System.Globalization;
 
 namespace Bonsai.Gui.Visualizers
 {
-    partial class GraphPanelView : GraphPanel
+    partial class RollingGraphPanelView : RollingGraphPanel
     {
-        readonly ToolStripEditableLabel minEditableLabelX;
-        readonly ToolStripEditableLabel maxEditableLabelX;
-        readonly ToolStripEditableLabel minEditableLabelY;
-        readonly ToolStripEditableLabel maxEditableLabelY;
+        readonly ToolStripEditableLabel minEditableLabel;
+        readonly ToolStripEditableLabel maxEditableLabel;
         readonly ToolStripEditableLabel capacityEditableLabel;
         readonly ToolStripEditableLabel spanEditableLabel;
 
-        public GraphPanelView()
+        public RollingGraphPanelView()
         {
             InitializeComponent();
-            autoScaleButtonX.Checked = true;
-            autoScaleButtonY.Checked = true;
+            autoScaleButton.Checked = true;
             spanEditableLabel = new ToolStripEditableLabel(spanValueLabel, OnSpanEdit);
             capacityEditableLabel = new ToolStripEditableLabel(capacityValueLabel, OnCapacityEdit);
-            minEditableLabelX = new ToolStripEditableLabel(minStatusLabelX, OnXMinEdit);
-            maxEditableLabelX = new ToolStripEditableLabel(maxStatusLabelX, OnXMaxEdit);
-            minEditableLabelY = new ToolStripEditableLabel(minStatusLabelY, OnYMinEdit);
-            maxEditableLabelY = new ToolStripEditableLabel(maxStatusLabelY, OnYMaxEdit);
+            minEditableLabel = new ToolStripEditableLabel(minStatusLabel, OnMinEdit);
+            maxEditableLabel = new ToolStripEditableLabel(maxStatusLabel, OnMaxEdit);
             GraphPane.AxisChangeEvent += GraphPane_AxisChangeEvent;
             MouseMoveEvent += GraphPanelView_MouseMoveEvent;
             MouseClick += GraphPanelView_MouseClick;
             components.Add(spanEditableLabel);
             components.Add(capacityEditableLabel);
-            components.Add(minEditableLabelX);
-            components.Add(maxEditableLabelX);
-            components.Add(minEditableLabelY);
-            components.Add(maxEditableLabelY);
+            components.Add(minEditableLabel);
+            components.Add(maxEditableLabel);
         }
 
         protected StatusStrip StatusStrip
@@ -53,40 +46,30 @@ namespace Bonsai.Gui.Visualizers
             set { capacityEditableLabel.Enabled = value; }
         }
 
-        public bool AutoScaleXVisible
+        public bool AutoScaleVisible
         {
-            get { return autoScaleButtonX.Visible; }
+            get { return autoScaleButton.Visible; }
             set
             {
-                autoScaleButtonX.Visible = value;
-                minEditableLabelX.Enabled = value;
-                maxEditableLabelX.Enabled = value;
+                autoScaleButton.Visible = value;
+                minEditableLabel.Enabled = value;
+                maxEditableLabel.Enabled = value;
             }
         }
 
-        public bool AutoScaleYVisible
+        private bool IsTimeSpan
         {
-            get { return autoScaleButtonY.Visible; }
-            set
+            get
             {
-                autoScaleButtonY.Visible = value;
-                minEditableLabelY.Enabled = value;
-                maxEditableLabelY.Enabled = value;
+                var baseAxis = GraphPane.BarSettings.BarBaseAxis();
+                return baseAxis.Type == AxisType.Date || baseAxis.Type == AxisType.DateAsOrdinal;
             }
         }
 
-        public bool IsTimeSpan { get; set; }
-
-        public event EventHandler AutoScaleXChanged
+        public event EventHandler AutoScaleChanged
         {
-            add { autoScaleButtonX.CheckedChanged += value; }
-            remove { autoScaleButtonX.CheckedChanged -= value; }
-        }
-
-        public event EventHandler AutoScaleYChanged
-        {
-            add { autoScaleButtonY.CheckedChanged += value; }
-            remove { autoScaleButtonY.CheckedChanged -= value; }
+            add { autoScaleButton.CheckedChanged += value; }
+            remove { autoScaleButton.CheckedChanged -= value; }
         }
 
         public event EventHandler AxisChanged;
@@ -121,33 +104,22 @@ namespace Bonsai.Gui.Visualizers
         {
             var span = Span;
             var capacity = Capacity;
-            var scaleX = pane.XAxis.Scale;
-            var scaleY = pane.YAxis.Scale;
-            autoScaleButtonX.Checked = pane.XAxis.Scale.MaxAuto;
-            autoScaleButtonY.Checked = pane.YAxis.Scale.MaxAuto;
+            var scale = ScaleAxis.Scale;
+            autoScaleButton.Checked = scale.MaxAuto;
             spanValueLabel.Text = IsTimeSpan
                 ? TimeSpan.FromDays(span).ToString()
                 : span.ToString("G5", CultureInfo.InvariantCulture);
             capacityValueLabel.Text = capacity.ToString(CultureInfo.InvariantCulture);
-            minStatusLabelX.Text = scaleX.Min.ToString("G5", CultureInfo.InvariantCulture);
-            maxStatusLabelX.Text = scaleX.Max.ToString("G5", CultureInfo.InvariantCulture);
-            minStatusLabelY.Text = scaleY.Min.ToString("G5", CultureInfo.InvariantCulture);
-            maxStatusLabelY.Text = scaleY.Max.ToString("G5", CultureInfo.InvariantCulture);
+            minStatusLabel.Text = scale.Min.ToString("G5", CultureInfo.InvariantCulture);
+            maxStatusLabel.Text = scale.Max.ToString("G5", CultureInfo.InvariantCulture);
             OnAxisChanged(EventArgs.Empty);
         }
 
-        private void autoScaleButtonX_CheckedChanged(object sender, EventArgs e)
+        private void autoScaleButton_CheckedChanged(object sender, EventArgs e)
         {
-            AutoScaleX = autoScaleButtonX.Checked;
-            minStatusLabelX.Visible = !autoScaleButtonX.Checked;
-            maxStatusLabelX.Visible = !autoScaleButtonX.Checked;
-        }
-
-        private void autoScaleButtonY_CheckedChanged(object sender, EventArgs e)
-        {
-            AutoScaleY = autoScaleButtonY.Checked;
-            minStatusLabelY.Visible = !autoScaleButtonY.Checked;
-            maxStatusLabelY.Visible = !autoScaleButtonY.Checked;
+            AutoScale = autoScaleButton.Checked;
+            minStatusLabel.Visible = !autoScaleButton.Checked;
+            maxStatusLabel.Visible = !autoScaleButton.Checked;
         }
 
         private void OnSpanEdit(string text)
@@ -173,35 +145,19 @@ namespace Bonsai.Gui.Visualizers
             }
         }
 
-        private void OnXMinEdit(string text)
+        private void OnMinEdit(string text)
         {
             if (double.TryParse(text, out double min))
             {
-                XMin = min;
+                Min = min;
             }
         }
 
-        private void OnXMaxEdit(string text)
+        private void OnMaxEdit(string text)
         {
             if (double.TryParse(text, out double max))
             {
-                XMax = max;
-            }
-        }
-
-        private void OnYMinEdit(string text)
-        {
-            if (double.TryParse(text, out double min))
-            {
-                YMin = min;
-            }
-        }
-
-        private void OnYMaxEdit(string text)
-        {
-            if (double.TryParse(text, out double max))
-            {
-                YMax = max;
+                Max = max;
             }
         }
     }

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.resx
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanelView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/Bonsai.Gui.Visualizers/RollingGraphPanelVisualizer.cs
+++ b/src/Bonsai.Gui.Visualizers/RollingGraphPanelVisualizer.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Windows.Forms;
+using Bonsai.Design;
+using Bonsai.Expressions;
+using ZedGraph;
+
+namespace Bonsai.Gui.Visualizers
+{
+    /// <summary>
+    /// Provides a type visualizer that can be used to overlay multiple plots sharing
+    /// the same index axis in a single graph panel.
+    /// </summary>
+    public class RollingGraphPanelVisualizer : MashupControlVisualizerBase<GraphControl, RollingGraphPanelBuilder>
+    {
+        Type indexType;
+        BarSettings barSettings;
+        RollingGraphPanelBuilder graphBuilder;
+
+        /// <summary>
+        /// Gets or sets the maximum span of data displayed at any one moment in the graph.
+        /// </summary>
+        public double Span { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of points displayed at any one moment in the graph.
+        /// </summary>
+        public int Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lower limit of the axis range when using a fixed scale.
+        /// </summary>
+        public double Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upper limit of the axis range when using a fixed scale.
+        /// </summary>
+        public double Max { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the axis range should be recalculated
+        /// automatically as the graph updates.
+        /// </summary>
+        public bool AutoScale { get; set; } = true;
+
+        internal BarSettings BarSettings => barSettings;
+
+        private Axis BarBaseAxis()
+        {
+            return graphBuilder.BaseAxis switch
+            {
+                BarBase.Y => Control.GraphPane.YAxis,
+                BarBase.Y2 => Control.GraphPane.Y2Axis,
+                BarBase.X2 => Control.GraphPane.X2Axis,
+                _ => Control.GraphPane.XAxis
+            };
+        }
+
+        internal void EnsureIndex(Type type)
+        {
+            if (indexType == null)
+            {
+                indexType = type;
+                var baseAxis = BarBaseAxis();
+                if (type == typeof(string))
+                {
+                    GraphHelper.FormatOrdinalAxis(baseAxis, indexType);
+                }
+                if (type == typeof(XDate))
+                {
+                    GraphHelper.FormatLinearDateAxis(baseAxis);
+                }
+            }
+            else ThrowHelper.ThrowIfNotEquals(indexType, type, "Only overlays with identical axis are allowed.");
+        }
+
+        internal void EnsureBarSettings(BarSettings settings)
+        {
+            const string ErrorMessage = "All bar graph overlays must have bar settings compatible with the graph panel.";
+            ThrowHelper.ThrowIfNotEquals(barSettings.Base, settings.Base, ErrorMessage);
+            ThrowHelper.ThrowIfNotEquals(barSettings.ClusterScaleWidth, settings.ClusterScaleWidth, ErrorMessage);
+            ThrowHelper.ThrowIfNotEquals(barSettings.ClusterScaleWidthAuto, settings.ClusterScaleWidthAuto, ErrorMessage);
+            ThrowHelper.ThrowIfNotEquals(barSettings.MinBarGap, settings.MinBarGap, ErrorMessage);
+            ThrowHelper.ThrowIfNotEquals(barSettings.MinClusterGap, settings.MinClusterGap, ErrorMessage);
+            ThrowHelper.ThrowIfNotEquals(barSettings.Type, settings.Type, ErrorMessage);
+        }
+
+        /// <inheritdoc/>
+        protected override GraphControl CreateControl(IServiceProvider provider, RollingGraphPanelBuilder builder)
+        {
+            var view = new RollingGraphPanelView();
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var graphPanelBuilder = (RollingGraphPanelBuilder)ExpressionBuilder.GetVisualizerElement(context.Source).Builder;
+            var controller = graphPanelBuilder.Controller;
+            view.GraphPane.XAxis.Scale.IsReverse = controller.ReverseX;
+            view.GraphPane.YAxis.Scale.IsReverse = controller.ReverseY;
+            barSettings = view.GraphPane.BarSettings;
+            barSettings.Base = controller.BaseAxis;
+            barSettings.Type = controller.BarType;
+
+            if (controller.Min.HasValue || controller.Max.HasValue)
+            {
+                view.AutoScale = false;
+                view.AutoScaleVisible = false;
+                view.Min = controller.Min.GetValueOrDefault();
+                view.Max = controller.Max.GetValueOrDefault();
+            }
+            else
+            {
+                view.AutoScale = AutoScale;
+                if (!AutoScale)
+                {
+                    view.Min = Min;
+                    view.Max = Max;
+                }
+            }
+
+            if (controller.Capacity.HasValue)
+            {
+                view.Capacity = controller.Capacity.Value;
+                view.CanEditCapacity = false;
+            }
+            else
+            {
+                view.Capacity = Capacity;
+                view.CanEditCapacity = true;
+            }
+
+            if (controller.Span.HasValue)
+            {
+                view.Span = controller.Span.Value;
+                view.CanEditSpan = false;
+            }
+            else
+            {
+                view.Span = Span;
+                view.CanEditSpan = true;
+            }
+
+            view.Dock = DockStyle.Fill;
+            view.HandleDestroyed += delegate
+            {
+                Min = view.Min;
+                Max = view.Max;
+                AutoScale = view.AutoScale;
+                Capacity = view.Capacity;
+                Span = view.Span;
+            };
+            graphBuilder = builder;
+            return view;
+        }
+
+        /// <inheritdoc/>
+        protected override void LoadMashupSource(int index, MashupSource mashupSource, IServiceProvider provider)
+        {
+            Control.ResetColorCycle();
+            base.LoadMashupSource(index, mashupSource, provider);
+        }
+
+        /// <inheritdoc/>
+        public override void Unload()
+        {
+            base.Unload();
+            indexType = null;
+            barSettings = null;
+            graphBuilder = null;
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to extend support for graph mashup by refactoring `GraphPanel` to allow composition of 2D line graphs and introducing `RollingGraphPanel` to support composition of both rolling graphs and bar graphs for displaying trends over time. The design goal for both graph panel types is below:
- `RollingGraphPanel`: typically used to represent trends or patterns in the data over time
- `GraphPanel`: typically used to show the relationship between two or more variables

The two types of composition panels are expected to evolve significantly in the near future, so the current API must be treated as highly experimental and subject to change.