### PR TITLE
Rename property grid auto refresh for clarity

### DIFF
--- a/src/Bonsai.Gui/PropertyGridBuilder.cs
+++ b/src/Bonsai.Gui/PropertyGridBuilder.cs
@@ -13,7 +13,7 @@ namespace Bonsai.Gui
     {
         internal readonly BehaviorSubject<bool> _HelpVisible = new(true);
         internal readonly BehaviorSubject<bool> _ToolbarVisible = new(true);
-        internal readonly BehaviorSubject<bool> _RefreshProperties = new(false);
+        internal readonly BehaviorSubject<bool> _AutoRefresh = new(false);
 
         /// <summary>
         /// Gets or sets a value specifying whether the help text box is visible.
@@ -43,10 +43,10 @@ namespace Bonsai.Gui
         /// </summary>
         [Category(nameof(CategoryAttribute.Behavior))]
         [Description("Specifies whether the property grid should refresh whenever the value of any property changes.")]
-        public bool RefreshProperties
+        public bool AutoRefresh
         {
-            get => _RefreshProperties.Value;
-            set => _RefreshProperties.OnNext(value);
+            get => _AutoRefresh.Value;
+            set => _AutoRefresh.OnNext(value);
         }
     }
 }

--- a/src/Bonsai.Gui/PropertyGridVisualizer.cs
+++ b/src/Bonsai.Gui/PropertyGridVisualizer.cs
@@ -23,7 +23,7 @@ namespace Bonsai.Gui
             propertyGrid.Site = new ServiceProviderContext(provider);
             propertyGrid.SubscribeTo(builder._HelpVisible, value => propertyGrid.HelpVisible = value);
             propertyGrid.SubscribeTo(builder._ToolbarVisible, value => propertyGrid.ToolbarVisible = value);
-            propertyGrid.SubscribeTo(builder._RefreshProperties, value =>
+            propertyGrid.SubscribeTo(builder._AutoRefresh, value =>
             {
                 if (value)
                 {
@@ -45,7 +45,7 @@ namespace Bonsai.Gui
         {
             var propertyGrid = (PropertyGrid)sender;
             var builder = (PropertyGridBuilder)propertyGrid.Tag;
-            if (builder._RefreshProperties.Value)
+            if (builder._AutoRefresh.Value)
             {
                 propertyGrid.Refresh();
             }


### PR DESCRIPTION
The current property `RefreshProperties` might be confused with the existing attribute and enum [`RefreshProperties`](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.refreshproperties?view=net-8.0) from the component model namespace, which has related but significantly different semantics. This PR renames this property to `AutoRefresh` for clarity.