### PR TITLE
Check if GraphPane is null before attempting to modify CurveList

### DIFF
--- a/src/Bonsai.Gui.ZedGraph/BoundedGraphPanel.cs
+++ b/src/Bonsai.Gui.ZedGraph/BoundedGraphPanel.cs
@@ -41,6 +41,10 @@ namespace Bonsai.Gui.ZedGraph
 
         protected override void OnInvalidated(InvalidateEventArgs e)
         {
+            if (GraphPane is null)
+            {
+                return;
+            }
             double? maxValue = null;
             var curveList = GraphPane.CurveList;
             for (int i = 0; i < curveList.Count; i++)


### PR DESCRIPTION
This PR makes a change to the `BoundedGraphPanel` class, specifically the `OnInvalidated` method, to check if the `GraphPane` is null before attempting to interact with the `GraphPane`. On Linux/Mono, the `OnInvalidated` method is being called before the `GraphPane` is initialised, leading to an error when attempting to call `GraphPane.CurveList`. This seems to be a Linux specific issue, since the original code works fine on Windows. I've tested on Windows as well with the new modification and it seems to work okay.